### PR TITLE
Fixing missing dependency for create-hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "buffer": "=4.9.1",
     "bytebuffer": "=5.0.1",
     "create-hmac": "^1.1.4",
+    "create-hash": "=1.1.2",
     "crypto-browserify": "=3.11.0",
     "ecdsa": "^0.7.0",
     "ecurve": "^1.0.5",


### PR DESCRIPTION
without this the library does not work. This is the same version that crypto-browserify uses but is made available to the system in the way it should be.