### PR TITLE
Add Travis-CI Support and ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,14 @@
+{
+  "env": {
+    "browser": true,
+    "mocha": true,
+    "node": true
+  },
+  "extends": [
+    "eslint:recommended",
+  ],
+  "rules": {
+    "func-names": ["error", "never"],
+    "max-len": ["error", 140, { "ignoreComments": true }]
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ before_script:
   - npm install
 
 script:
-  - npm run lint
+  #- npm run lint
   - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js: "6.11"
+
+before_script:
+  - npm install
+
+script:
+  - npm run lint
+  - npm run test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ark JS
 
+[![Build Status](https://travis-ci.org/ArkEcosystem/ark-js.svg?branch=master)](https://travis-ci.org/ArkEcosystem/ark-js)
+
 Ark JS is a JavaScript library for sending Ark transactions. It's main benefit is that it does not require a locally installed Ark node, and instead utilizes the existing peers on the network. It can be used from the client as a [browserify](http://browserify.org/) compiled module, or on the server as a standard Node.js module.
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "JavaScript library for sending Ark transactions from the client or server",
   "main": "index.js",
   "scripts": {
+    "lint": "eslint .",
     "test": "mocha test/ark.js test/*/*"
   },
   "repository": {
@@ -31,8 +32,9 @@
     "wif": "^2.0.4"
   },
   "devDependencies": {
+    "eslint": "^4.2.0",
     "proxyquire": "^1.7.10",
-    "sinon": "^1.17.7",
-    "should": "=11.1.0"
+    "should": "=11.1.0",
+    "sinon": "^1.17.7"
   }
 }


### PR DESCRIPTION
I've added Travis-CI support and ESLint.

Currently the travis-ci build will only run the tests, as the rules for the lint need to be decided. I've used the eslint:recommended rules, and added a max line length of 140, but there are quite a few issues.

This is helpful for reviewing pull request standards, as the code will have to follow the standards once the lint has been sorted.

In order to setup Travis, any dev that is part of the ArkEcosystem organisation can register on travis-ci.org, and activate the repository on Travis. Any pull requests or commits after that will trigger a travis-ci build.

I would recommend enabling the repository on travis-ci before the pull request is activated, then the first build will be this commit.