### PR TITLE
Fix missing dependency - create-hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "buffer": "=4.9.1",
     "bytebuffer": "=5.0.1",
     "create-hmac": "^1.1.4",
+    "create-hash": "=1.1.3",
     "crypto-browserify": "=3.11.0",
     "ecdsa": "^0.7.0",
     "ecurve": "^1.0.5",


### PR DESCRIPTION
module.js:340
    throw err;
          ^
Error: Cannot find module 'create-hash'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/usr/lib/node_modules/arkjs/lib/crypto.js:1:80)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)

$ sudo npm install -g create-hash
create-hash@1.1.3 /usr/lib/node_modules/create-hash
├── inherits@2.0.3
├── sha.js@2.4.8
├── ripemd160@2.0.1 (hash-base@2.0.2)
└── cipher-base@1.0.4 (safe-buffer@5.1.1)