### PR TITLE
Add jsdoc scaffold and scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ build/Release
 node_modules
 jspm_packages
 
+# Generated doc directory
+docs
+
 # Optional npm cache directory
 .npm
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+/** @module arkjs */
+
 ark = {
 	crypto : require("./lib/transactions/crypto.js"),
 	delegate : require("./lib/transactions/delegate.js"),
@@ -20,4 +22,5 @@ for (var method in libCrypto) {
 	ark.crypto[method] = libCrypto[method]
 }
 
+/** The arkjs exported object. */
 module.exports = ark;

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,10 @@
+{
+  "plugins": ["plugins/markdown"],
+  "source": {
+    "include": ["README.md", "index.js"]
+  },
+  "opts": {
+    "destination": "./docs",
+    "recurse": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "JavaScript library for sending Ark transactions from the client or server",
   "main": "index.js",
   "scripts": {
+    "build:docs": "jsdoc -c jsdoc.json",
+    "clean": "shx rm -r ./docs",
     "lint": "eslint .",
     "test": "mocha test/ark.js test/*/*"
   },
@@ -41,8 +43,8 @@
     "bs58check": "^1.1.1",
     "buffer": "=4.9.1",
     "bytebuffer": "=5.0.1",
-    "create-hmac": "^1.1.4",
     "create-hash": "=1.1.3",
+    "create-hmac": "^1.1.4",
     "crypto-browserify": "=3.11.0",
     "ecdsa": "^0.7.0",
     "ecurve": "^1.0.5",
@@ -54,9 +56,11 @@
   },
   "devDependencies": {
     "eslint": "^4.2.0",
+    "jsdoc": "^3.5.5",
     "mocha": "=3.1.0",
     "proxyquire": "^1.7.10",
     "should": "=11.1.0",
+    "shx": "^0.2.2",
     "sinon": "^1.17.7"
   }
 }


### PR DESCRIPTION
Now we can build documentation!

- Added dev dependencies `jsdoc` and `shx`.
- Added a `jsdoc.json` that references the readme and top object.
- `npm build:docs` creates documentation under `docs/`.
- `npm clean` removes `docs/`.