### PR TITLE
Add multiple version testing to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
-node_js: "6.11"
-
-before_script:
-  - npm install
+node_js:
+  - 8
+  - 7
+  - 6
+  - 5
+  - 4
 
 script:
   #- npm run lint

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.2.1",
   "description": "JavaScript library for sending Ark transactions from the client or server",
   "main": "index.js",
+  "engines": {
+    "node": ">=4"
+  },
   "scripts": {
     "lint": "eslint .",
     "test": "mocha test/ark.js test/*/*"


### PR DESCRIPTION
Covers all node versions from 4 onwards. (A simple dependency analysis showed 4 was the minimum required version.) In the future we should add a CI trigger to push static documentation builds onto github pages when merging into main.