### PR TITLE
Sign transactions using ECPair

### DIFF
--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -18,6 +18,10 @@ var fixedPoint = Math.pow(10, 8);
 // default is ark mainnet
 var networkVersion = 0x17;
 
+function isECPair(obj) {
+	return obj instanceof ECPair;
+}
+
 function getSignatureBytes(signature) {
 	var bb = new ByteBuffer(33, true);
 	var publicKeyBuffer = new Buffer(signature.publicKey, "hex");
@@ -412,5 +416,6 @@ module.exports = {
 	verifySecondSignature: verifySecondSignature,
 	fixedPoint: fixedPoint,
 	setNetworkVersion: setNetworkVersion,
-	getNetworkVersion: getNetworkVersion
+	getNetworkVersion: getNetworkVersion,
+	isECPair: isECPair
 }

--- a/lib/transactions/delegate.js
+++ b/lib/transactions/delegate.js
@@ -3,7 +3,17 @@ var crypto = require("./crypto.js"),
     slots = require("../time/slots.js");
 
 function createDelegate(secret, username, secondSecret) {
-	var keys = crypto.getKeys(secret);
+	if (!secret || !username) return false;
+
+	var keys = secret;
+
+	if (!crypto.isECPair(secret)) {
+		keys = crypto.getKeys(secret);
+	}
+
+	if (!keys.publicKey) {
+		throw new Error("Invalid public key");
+	}
 
 	var transaction = {
 		type: 2,
@@ -23,7 +33,10 @@ function createDelegate(secret, username, secondSecret) {
 	crypto.sign(transaction, keys);
 
 	if (secondSecret) {
-		var secondKeys = crypto.getKeys(secondSecret);
+		var secondKeys = secondSecret;
+		if (!crypto.isECPair(secondSecret)) {
+			secondKeys = crypto.getKeys(secondSecret);
+		}
 		crypto.secondSign(transaction, secondKeys);
 	}
 

--- a/lib/transactions/ipfs.js
+++ b/lib/transactions/ipfs.js
@@ -3,6 +3,8 @@ var crypto = require("./crypto.js"),
     slots = require("../time/slots.js");
 
 function createHashRegistration(ipfshash, secret, secondSecret) {
+	if (!ipfshash || !secret) return false;
+
 	var transaction = {
 		type: 5,
     amount:0,
@@ -15,15 +17,27 @@ function createHashRegistration(ipfshash, secret, secondSecret) {
   //filling with 0x00
   while(transaction.vendorFieldHex.length < 128){
     transaction.vendorFieldHex = "00"+transaction.vendorFieldHex;
-  }
+	}
 
-	var keys = crypto.getKeys(secret);
+	var keys = secret;
+
+	if (!crypto.isECPair(secret)) {
+		keys = crypto.getKeys(secret);
+	}
+
+	if (!keys.publicKey) {
+		throw new Error("Invalid public key");
+	}
+
 	transaction.senderPublicKey = keys.publicKey;
 
 	crypto.sign(transaction, keys);
 
 	if (secondSecret) {
-		var secondKeys = crypto.getKeys(secondSecret);
+		var secondKeys = secondSecret;
+		if (!crypto.isECPair(secondSecret)) {
+			secondKeys = crypto.getKeys(secondSecret);
+		}
 		crypto.secondSign(transaction, secondKeys);
 	}
 

--- a/lib/transactions/multisignature.js
+++ b/lib/transactions/multisignature.js
@@ -3,14 +3,27 @@ var crypto = require("./crypto.js"),
     slots = require("../time/slots.js");
 
 function signTransaction(trs, secret) {
-	var keys = crypto.getKeys(secret);
+	if (!trs || !secret) return false;
+
+	var keys = secret;
+
+	if (!crypto.isECPair(secret)) {
+		keys = crypto.getKeys(secret);
+	}
+
 	var signature = crypto.sign(trs, keys);
 
 	return signature;
 }
 
 function createMultisignature(secret, secondSecret, keysgroup, lifetime, min) {
-	var keys = crypto.getKeys(secret);
+	if (!secret || !keysgroup || !lifetime || !min) return false;
+
+	var keys = secret;
+
+	if (!crypto.isECPair(secret)) {
+		keys = crypto.getKeys(secret);
+	}
 
 	var transaction = {
 		type: 4,
@@ -31,7 +44,10 @@ function createMultisignature(secret, secondSecret, keysgroup, lifetime, min) {
 	crypto.sign(transaction, keys);
 
 	if (secondSecret) {
-		var secondKeys = crypto.getKeys(secondSecret);
+		var secondKeys = secondSecret;
+		if (!crypto.isECPair(secondSecret)) {
+			secondKeys = crypto.getKeys(secondSecret);
+		}
 		crypto.secondSign(transaction, secondKeys);
 	}
 

--- a/lib/transactions/signature.js
+++ b/lib/transactions/signature.js
@@ -13,7 +13,17 @@ function newSignature(secondSecret) {
 }
 
 function createSignature(secret, secondSecret) {
-	var keys = crypto.getKeys(secret);
+	if (!secret || !secondSecret) return false;
+
+	var keys = secret;
+
+	if (!crypto.isECPair(secret)) {
+		keys = crypto.getKeys(secret);
+	}
+
+	if (!keys.publicKey) {
+    throw new Error("Invalid public key");
+  }
 
 	var signature = newSignature(secondSecret);
 	var transaction = {

--- a/lib/transactions/transaction.js
+++ b/lib/transactions/transaction.js
@@ -3,9 +3,22 @@ var crypto = require("./crypto.js"),
     slots = require("../time/slots.js");
 
 function createTransaction(recipientId, amount, vendorField, secret, secondSecret) {
+	if (!recipientId || !amount || !secret) return false;
+
   if(!crypto.validateAddress(recipientId)){
     throw new Error("Wrong recipientId");
+	}
+
+	var keys = secret;
+
+	if (!crypto.isECPair(secret)) {
+		keys = crypto.getKeys(secret);
+	}
+
+  if (!keys.publicKey) {
+    throw new Error("Invalid public key");
   }
+
 	var transaction = {
 		type: 0,
 		amount: amount,
@@ -22,13 +35,15 @@ function createTransaction(recipientId, amount, vendorField, secret, secondSecre
 		}
   }
 
-	var keys = crypto.getKeys(secret);
 	transaction.senderPublicKey = keys.publicKey;
 
 	crypto.sign(transaction, keys);
 
 	if (secondSecret) {
-		var secondKeys = crypto.getKeys(secondSecret);
+		var secondKeys = secondSecret;
+		if (!crypto.isECPair(secondSecret)) {
+			secondKeys = crypto.getKeys(secondSecret);
+		}
 		crypto.secondSign(transaction, secondKeys);
 	}
 

--- a/lib/transactions/vote.js
+++ b/lib/transactions/vote.js
@@ -3,7 +3,17 @@ var crypto = require("./crypto.js"),
     slots = require("../time/slots.js");
 
 function createVote(secret, delegates, secondSecret) {
-	var keys = crypto.getKeys(secret);
+	if (!secret || !Array.isArray(delegates)) return;
+
+	var keys = secret;
+
+	if (!crypto.isECPair(secret)) {
+		keys = crypto.getKeys(secret);
+  }
+
+  if (!keys.publicKey) {
+    throw new Error("Invalid public key");
+  }
 
 	var transaction = {
 		type: 3,
@@ -20,7 +30,10 @@ function createVote(secret, delegates, secondSecret) {
 	crypto.sign(transaction, keys);
 
 	if (secondSecret) {
-		var secondKeys = crypto.getKeys(secondSecret);
+		var secondKeys = secondSecret;
+		if (!crypto.isECPair(secondSecret)) {
+			secondKeys = crypto.getKeys(secondSecret);
+		}
 		crypto.secondSign(transaction, secondKeys);
 	}
 

--- a/test/multisignature/index.js
+++ b/test/multisignature/index.js
@@ -32,6 +32,18 @@ describe("multisignature.js", function () {
       (sgn).should.be.type("object");
     });
 
+    it("should create multisignature transaction from keys", function () {
+      var secretKey = ark.ECPair.fromSeed("secret");
+      secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex");
+
+      var secondSecretKey = ark.ECPair.fromSeed("second secret");
+      secondSecretKey.publicKey = secondSecretKey.getPublicKeyBuffer().toString("hex");
+
+      sgn = createMultisignature(secretKey, secondSecretKey,["03a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933","13a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933","23a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933"], 255, 2);
+      (sgn).should.be.ok;
+      (sgn).should.be.type("object");
+    });
+
     it("should be deserialised correctly", function () {
       var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(sgn).toString("hex"));
       delete deserialisedTx.vendorFieldHex;

--- a/test/signature/index.js
+++ b/test/signature/index.js
@@ -32,6 +32,15 @@ describe("signature.js", function () {
       (sgn).should.be.type("object");
     });
 
+    it("should create signature transaction", function () {
+      var secretKey = ark.ECPair.fromSeed("secret");
+      secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex");
+
+      sgn = createSignature(secretKey, "second secret");
+      (sgn).should.be.ok;
+      (sgn).should.be.type("object");
+    });
+
     it("should be deserialised correctly", function () {
       var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(sgn).toString("hex"));
       delete deserialisedTx.vendorFieldHex;

--- a/test/transaction/index.js
+++ b/test/transaction/index.js
@@ -27,6 +27,14 @@ describe("transaction.js", function () {
       (trs).should.be.ok;
     });
 
+    it("should create transaction without second signature from keys", function () {
+      var secretKey = ark.ECPair.fromSeed("secret");
+      secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex");
+
+      trs = createTransaction("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff", 1000, null, secretKey);
+      (trs).should.be.ok;
+    });
+
     it("should create transaction with vendorField", function () {
       trs = createTransaction("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff", 1000, "this is a test vendorfield", "secret");
       (trs).should.be.ok;

--- a/test/vote/index.js
+++ b/test/vote/index.js
@@ -2,6 +2,8 @@ var Buffer = require("buffer/").Buffer;
 var should = require("should");
 var ark = require("../../index.js");
 
+var NETWORKS = require('../../lib/networks');
+
 describe("vote.js", function () {
 
   var vote = ark.vote;
@@ -34,6 +36,26 @@ describe("vote.js", function () {
 
     it("should create vote", function () {
       vt = createVote("secret", publicKeys, "second secret");
+    });
+
+    it("should create vote from ecpair", function () {
+      var secretKey = ark.ECPair.fromSeed("secret");
+      secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex");
+
+      var secondSecretKey = ark.ECPair.fromSeed("second secret");
+      secondSecretKey.publicKey = secondSecretKey.getPublicKeyBuffer().toString("hex");
+
+      vt = createVote(secretKey, publicKeys, secondSecretKey);
+    });
+
+    it("should create vote from wif", function () {
+      var secretKey = ark.ECPair.fromWIF("SB3iDxYmKgjkhfDZSKgLaBrp3Ynzd3yd3ZZF2ujVBK7vLpv6hWKK", NETWORKS.ark);
+      secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex");
+
+      var tx = createVote(secretKey, publicKeys);
+      (tx).should.be.ok;
+      (tx).should.be.type("object");
+      (tx).should.have.property("recipientId").and.be.type("string").and.be.equal("AL9uJWA5nd6RWn8VSUzGN7spWeZGHeudg9");
     });
 
     it("should be deserialised correctly", function () {


### PR DESCRIPTION
Useful to sign transactions using passphrase, seed, WIF or entropy. Should resolve #11.