### PR TITLE
Normalize semicolons

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,10 @@
 {
   "env": {
     "browser": true,
-    "mocha": true,
     "node": true
   },
   "extends": [
-    "eslint:recommended",
+    "eslint:recommended"
   ],
   "rules": {
     "func-names": ["error", "never"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,10 @@
   ],
   "rules": {
     "func-names": ["error", "never"],
-    "max-len": ["error", 140, { "ignoreComments": true }]
+    "max-len": ["error", 140, { "ignoreComments": true }],
+    "no-unexpected-multiline": ["error"],
+    "semi": ["error", "never"],
+    "semi-spacing": ["error", {"before": false, "after": true}],
+    "semi-style": ["error", "last"]
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ before_script:
   - npm install
 
 script:
-  #- npm run lint
+  - npm run lint
   - npm run test

--- a/index.js
+++ b/index.js
@@ -23,4 +23,4 @@ for (var method in libCrypto) {
 }
 
 /** The arkjs exported object. */
-module.exports = ark;
+module.exports = ark

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-ark = {
+var ark = {
 	crypto : require("./lib/transactions/crypto.js"),
 	delegate : require("./lib/transactions/delegate.js"),
 	signature : require("./lib/transactions/signature.js"),

--- a/lib/ecpair.js
+++ b/lib/ecpair.js
@@ -1,6 +1,5 @@
 var base58check = require('bs58check')
 var bcrypto = require('./crypto')
-var ecdsa = require('./ecdsa')
 var ECSignature = require('./ecsignature')
 var randomBytes = require('randombytes')
 var typeforce = require('typeforce')

--- a/lib/ecsignature.js
+++ b/lib/ecsignature.js
@@ -29,7 +29,7 @@ ECSignature.parseNativeSecp256k1 = function (native) {
 
 ECSignature.prototype.toNativeSecp256k1 = function () {
   var buffer = new Buffer(64)
-  if(this.r.toBuffer().length > 32 || this.s.toBuffer().length > 32){
+  if(this.r.toBuffer().length > 32 || this.s.toBuffer().length > 32){
     return buffer;
   }
 

--- a/lib/ecsignature.js
+++ b/lib/ecsignature.js
@@ -40,7 +40,7 @@ ECSignature.parseNativeSecp256k1 = function (native) {
 ECSignature.prototype.toNativeSecp256k1 = function () {
   var buffer = new Buffer(64)
   if(this.r.toBuffer().length > 32 || this.s.toBuffer().length > 32){
-    return buffer;
+    return buffer
   }
 
   this.r.toBuffer(32).copy(buffer, 0)

--- a/lib/time/slots.js
+++ b/lib/time/slots.js
@@ -4,11 +4,11 @@
  */
 function getEpochTime(time) {
 	if (time === undefined) {
-		time = (new Date()).getTime();
+		time = (new Date()).getTime()
 	}
-	var d = beginEpochTime();
-	var t = d.getTime();
-	return Math.floor((time - t) / 1000);
+	var d = beginEpochTime()
+	var t = d.getTime()
+	return Math.floor((time - t) / 1000)
 }
 
 /**
@@ -17,18 +17,18 @@ function getEpochTime(time) {
 function beginEpochTime() {
 	var d = new Date(Date.UTC(2017,2,21,13,0,0,0))
 
-	return d;
+	return d
 }
 
 var interval = 8,
-    delegates = 51;
+    delegates = 51
 
 /**
  * @param {Date=} time
  * @returns {number}
  */
 function getTime(time) {
-	return getEpochTime(time);
+	return getEpochTime(time)
 }
 
 /**
@@ -39,9 +39,9 @@ function getRealTime(epochTime) {
 	if (epochTime === undefined) {
 		epochTime = getTime()
 	}
-	var d = beginEpochTime();
-	var t = Math.floor(d.getTime() / 1000) * 1000;
-	return t + epochTime * 1000;
+	var d = beginEpochTime()
+	var t = Math.floor(d.getTime() / 1000) * 1000
+	return t + epochTime * 1000
 }
 
 /**
@@ -53,7 +53,7 @@ function getSlotNumber(epochTime) {
 		epochTime = getTime()
 	}
 
-	return Math.floor(epochTime / interval);
+	return Math.floor(epochTime / interval)
 }
 
 /**
@@ -61,16 +61,16 @@ function getSlotNumber(epochTime) {
  * @returns {number}
  */
 function getSlotTime(slot) {
-	return slot * interval;
+	return slot * interval
 }
 
 /**
  * @returns {number}
  */
 function getNextSlot() {
-	var slot = getSlotNumber();
+	var slot = getSlotNumber()
 
-	return slot + 1;
+	return slot + 1
 }
 
 /**
@@ -78,7 +78,7 @@ function getNextSlot() {
  * @returns {number}
  */
 function getLastSlot(nextSlot) {
-	return nextSlot + delegates;
+	return nextSlot + delegates
 }
 
 module.exports = {

--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -1,396 +1,396 @@
-var crypto = require("crypto");
-var crypto_utils = require("../crypto.js");
-var ECPair = require("../ecpair.js");
-var ECSignature = require("../ecsignature.js");
+var crypto = require("crypto")
+var crypto_utils = require("../crypto.js")
+var ECPair = require("../ecpair.js")
+var ECSignature = require("../ecsignature.js")
 var networks = require("../networks.js")
 
 var bs58check = require('bs58check')
 
 if (typeof Buffer === "undefined") {
-	Buffer = require("buffer/").Buffer; // eslint-disable-line no-global-assign
+	Buffer = require("buffer/").Buffer // eslint-disable-line no-global-assign
 }
 
-var ByteBuffer = require("bytebuffer");
+var ByteBuffer = require("bytebuffer")
 
-var fixedPoint = Math.pow(10, 8);
+var fixedPoint = Math.pow(10, 8)
 // default is ark mainnet
-var networkVersion = 0x17;
+var networkVersion = 0x17
 
 function isECPair(obj) {
-	return obj instanceof ECPair;
+	return obj instanceof ECPair
 }
 
 function getSignatureBytes(signature) {
-	var bb = new ByteBuffer(33, true);
-	var publicKeyBuffer = new Buffer(signature.publicKey, "hex");
+	var bb = new ByteBuffer(33, true)
+	var publicKeyBuffer = new Buffer(signature.publicKey, "hex")
 
 	for (var i = 0; i < publicKeyBuffer.length; i++) {
-		bb.writeByte(publicKeyBuffer[i]);
+		bb.writeByte(publicKeyBuffer[i])
 	}
 
-	bb.flip();
-	return new Uint8Array(bb.toArrayBuffer()); // eslint-disable-line no-undef
+	bb.flip()
+	return new Uint8Array(bb.toArrayBuffer()) // eslint-disable-line no-undef
 }
 
 function getBytes(transaction, skipSignature, skipSecondSignature) {
 	var assetSize = 0,
-		assetBytes = null;
+		assetBytes = null
 
 	switch (transaction.type) {
 		case 1: // Signature
-			assetBytes = getSignatureBytes(transaction.asset.signature);
-			assetSize = assetBytes.length;
-			break;
+			assetBytes = getSignatureBytes(transaction.asset.signature)
+			assetSize = assetBytes.length
+			break
 
 		case 2: // Delegate
-			assetBytes = new Buffer(transaction.asset.delegate.username, "utf8");
-			assetSize = assetBytes.length;
-			break;
+			assetBytes = new Buffer(transaction.asset.delegate.username, "utf8")
+			assetSize = assetBytes.length
+			break
 
 		case 3: // Vote
 			if (transaction.asset.votes !== null) {
-				assetBytes = new Buffer(transaction.asset.votes.join(""), "utf8");
-				assetSize = assetBytes.length;
+				assetBytes = new Buffer(transaction.asset.votes.join(""), "utf8")
+				assetSize = assetBytes.length
 			}
-			break;
+			break
 
 		case 4: // Multi-Signature
-			var keysgroupBuffer = new Buffer(transaction.asset.multisignature.keysgroup.join(""), "utf8");
-			var bb = new ByteBuffer(1 + 1 + keysgroupBuffer.length, true);
+			var keysgroupBuffer = new Buffer(transaction.asset.multisignature.keysgroup.join(""), "utf8")
+			var bb = new ByteBuffer(1 + 1 + keysgroupBuffer.length, true)
 
-			bb.writeByte(transaction.asset.multisignature.min);
-			bb.writeByte(transaction.asset.multisignature.lifetime);
+			bb.writeByte(transaction.asset.multisignature.min)
+			bb.writeByte(transaction.asset.multisignature.lifetime)
 
 			for (var i = 0; i < keysgroupBuffer.length; i++) {
-				bb.writeByte(keysgroupBuffer[i]);
+				bb.writeByte(keysgroupBuffer[i])
 			}
 
-			bb.flip();
+			bb.flip()
 
-			assetBytes = bb.toBuffer();
-			assetSize  = assetBytes.length;
-			break;
+			assetBytes = bb.toBuffer()
+			assetSize  = assetBytes.length
+			break
 
 	}
 
-	bb = new ByteBuffer(1 + 4 + 32 + 8 + 8 + 21 + 64 + 64 + 64 + assetSize, true);
-	bb.writeByte(transaction.type);
-	bb.writeInt(transaction.timestamp);
+	bb = new ByteBuffer(1 + 4 + 32 + 8 + 8 + 21 + 64 + 64 + 64 + assetSize, true)
+	bb.writeByte(transaction.type)
+	bb.writeInt(transaction.timestamp)
 
-	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
+	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex")
 	for (i = 0; i < senderPublicKeyBuffer.length; i++) {
-		bb.writeByte(senderPublicKeyBuffer[i]);
+		bb.writeByte(senderPublicKeyBuffer[i])
 	}
 
 	if (transaction.recipientId) {
-		var recipient = bs58check.decode(transaction.recipientId);
+		var recipient = bs58check.decode(transaction.recipientId)
 		for (i = 0; i < recipient.length; i++) {
-			bb.writeByte(recipient[i]);
+			bb.writeByte(recipient[i])
 		}
 	} else {
 		for (i = 0; i < 21; i++) {
-			bb.writeByte(0);
+			bb.writeByte(0)
 		}
 	}
 
 	if(transaction.vendorFieldHex){
-		var vf = new Buffer(transaction.vendorFieldHex,"hex");
-		var fillstart=vf.length;
+		var vf = new Buffer(transaction.vendorFieldHex,"hex")
+		var fillstart=vf.length
 		for (i = 0; i < fillstart; i++) {
-			bb.writeByte(vf[i]);
+			bb.writeByte(vf[i])
 		}
 		for (i = fillstart; i < 64; i++) {
-			bb.writeByte(0);
+			bb.writeByte(0)
 		}
 	}
 	else if (transaction.vendorField) {
-		vf = new Buffer(transaction.vendorField);
-		fillstart=vf.length;
+		vf = new Buffer(transaction.vendorField)
+		fillstart=vf.length
 		for (i = 0; i < fillstart; i++) {
-			bb.writeByte(vf[i]);
+			bb.writeByte(vf[i])
 		}
 		for (i = fillstart; i < 64; i++) {
-			bb.writeByte(0);
+			bb.writeByte(0)
 		}
 	} else {
 		for (i = 0; i < 64; i++) {
-			bb.writeByte(0);
+			bb.writeByte(0)
 		}
 	}
 
-	bb.writeLong(transaction.amount);
+	bb.writeLong(transaction.amount)
 
-	bb.writeLong(transaction.fee);
+	bb.writeLong(transaction.fee)
 
 	if (assetSize > 0) {
 		for (i = 0; i < assetSize; i++) {
-			bb.writeByte(assetBytes[i]);
+			bb.writeByte(assetBytes[i])
 		}
 	}
 
 	if (!skipSignature && transaction.signature) {
-		var signatureBuffer = new Buffer(transaction.signature, "hex");
+		var signatureBuffer = new Buffer(transaction.signature, "hex")
 		for (i = 0; i < signatureBuffer.length; i++) {
-			bb.writeByte(signatureBuffer[i]);
+			bb.writeByte(signatureBuffer[i])
 		}
 	}
 
 	if (!skipSecondSignature && transaction.signSignature) {
-		var signSignatureBuffer = new Buffer(transaction.signSignature, "hex");
+		var signSignatureBuffer = new Buffer(transaction.signSignature, "hex")
 		for (i = 0; i < signSignatureBuffer.length; i++) {
-			bb.writeByte(signSignatureBuffer[i]);
+			bb.writeByte(signSignatureBuffer[i])
 		}
 	}
 
-	bb.flip();
-	var arrayBuffer = new Uint8Array(bb.toArrayBuffer()); // eslint-disable-line no-undef
-	var buffer = [];
+	bb.flip()
+	var arrayBuffer = new Uint8Array(bb.toArrayBuffer()) // eslint-disable-line no-undef
+	var buffer = []
 
 	for (i = 0; i < arrayBuffer.length; i++) {
-		buffer[i] = arrayBuffer[i];
+		buffer[i] = arrayBuffer[i]
 	}
 
-	return new Buffer(buffer);
+	return new Buffer(buffer)
 }
 
 function fromBytes(hexString){
-	var tx={};
-	var buf = new Buffer(hexString, "hex");
-	tx.type = buf.readInt8(0) & 0xff;
-	tx.timestamp = buf.readUInt32LE(1);
-	tx.senderPublicKey = hexString.substring(10,10+33*2);
-	tx.amount = buf.readUInt32LE(38+21+64);
-	tx.fee = buf.readUInt32LE(38+21+64+8);
-	tx.vendorFieldHex = hexString.substring(76+42,76+42+128);
-  tx.recipientId = bs58check.encode(buf.slice(38,38+21));
+	var tx={}
+	var buf = new Buffer(hexString, "hex")
+	tx.type = buf.readInt8(0) & 0xff
+	tx.timestamp = buf.readUInt32LE(1)
+	tx.senderPublicKey = hexString.substring(10,10+33*2)
+	tx.amount = buf.readUInt32LE(38+21+64)
+	tx.fee = buf.readUInt32LE(38+21+64+8)
+	tx.vendorFieldHex = hexString.substring(76+42,76+42+128)
+  tx.recipientId = bs58check.encode(buf.slice(38,38+21))
 	if(tx.type == 0){ // transfer
-		parseSignatures(hexString, tx, 76+42+128+32);
+		parseSignatures(hexString, tx, 76+42+128+32)
 	}
 	else if(tx.type == 1){ // second signature registration
-		delete tx.recipientId;
+		delete tx.recipientId
 		tx.asset = {
 			signature : {
 				publicKey : hexString.substring(76+42+128+32,76+42+128+32+66)
 			}
 		}
-		parseSignatures(hexString, tx, 76+42+128+32+66);
+		parseSignatures(hexString, tx, 76+42+128+32+66)
 	}
 	else if(tx.type == 2){ // delegate registration
-		delete tx.recipientId;
+		delete tx.recipientId
 		// Impossible to assess size of delegate asset, trying to grab signature and derive delegate asset
-		offset = findAndParseSignatures(hexString, tx);
+		offset = findAndParseSignatures(hexString, tx)
 
 		tx.asset = {
 			delegate: {
 				username: new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex").toString("utf8")
 			}
-		};
+		}
 	}
 	else if(tx.type == 3){ // vote
 		// Impossible to assess size of vote asset, trying to grab signature and derive vote asset
-		var offset = findAndParseSignatures(hexString, tx);
+		var offset = findAndParseSignatures(hexString, tx)
 		tx.asset = {
 			votes: new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex").toString("utf8").split(",")
-		};
+		}
 	}
 	else if(tx.type == 4){ // multisignature creation
-		delete tx.recipientId;
-		offset = findAndParseSignatures(hexString, tx);
+		delete tx.recipientId
+		offset = findAndParseSignatures(hexString, tx)
 		var buffer = new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex")
 		tx.asset = {
 			multisignature: {}
 		}
-		tx.asset.multisignature.min = buffer.readInt8(0) & 0xff;
-		tx.asset.multisignature.lifetime = buffer.readInt8(1) & 0xff;
-		tx.asset.multisignature.keysgroup = [];
-		var index = 0;
+		tx.asset.multisignature.min = buffer.readInt8(0) & 0xff
+		tx.asset.multisignature.lifetime = buffer.readInt8(1) & 0xff
+		tx.asset.multisignature.keysgroup = []
+		var index = 0
 		while(index + 2 < buffer.length){
-			var key = buffer.slice(index+2,index+66+2).toString("utf8");
-			tx.asset.multisignature.keysgroup.push(key);
-			index = index + 66;
+			var key = buffer.slice(index+2,index+66+2).toString("utf8")
+			tx.asset.multisignature.keysgroup.push(key)
+			index = index + 66
 		}
 	}
 	else if(tx.type == 5){ // ipfs
-		delete tx.recipientId;
-		parseSignatures(hexString, tx, 76+42+128+32);
+		delete tx.recipientId
+		parseSignatures(hexString, tx, 76+42+128+32)
 	}
-	return tx;
+	return tx
 }
 
 function findAndParseSignatures(hexString, tx){
-	var signature1 = new Buffer(hexString.substring(hexString.length-146), "hex");
-	var signature2 = null;
-	var found      = false;
-	var offset     = 0;
+	var signature1 = new Buffer(hexString.substring(hexString.length-146), "hex")
+	var signature2 = null
+	var found      = false
+	var offset     = 0
 	while(!found && signature1.length > 8){
 		if(signature1[0] != 0x30){
-			signature1 = signature1.slice(1);
+			signature1 = signature1.slice(1)
 		}
 		else try {
-			ECSignature.fromDER(signature1,"hex");
-			found = true;
+			ECSignature.fromDER(signature1,"hex")
+			found = true
 		} catch(error){
-			signature1 = signature1.slice(1);
+			signature1 = signature1.slice(1)
 		}
 	}
 	if(!found){
-		offset = 0;
-		signature1 = null;
+		offset = 0
+		signature1 = null
 	}
 	else {
-		found = false;
-		offset = signature1.length*2;
-		signature2 = new Buffer(hexString.substring(hexString.length-offset-146, hexString.length-offset), "hex");
+		found = false
+		offset = signature1.length*2
+		signature2 = new Buffer(hexString.substring(hexString.length-offset-146, hexString.length-offset), "hex")
 		while(!found && signature2.length > 8){
 			if(signature2[0] != 0x30){
-				signature2 = signature2.slice(1);
+				signature2 = signature2.slice(1)
 			}
 			else try {
-				ECSignature.fromDER(signature2,"hex");
-				found = true;
+				ECSignature.fromDER(signature2,"hex")
+				found = true
 			} catch(error){
-				signature2 = signature2.slice(1);
+				signature2 = signature2.slice(1)
 			}
 		}
 		if(!found){
-			signature2 = null;
-			tx.signature = signature1.toString("hex");
-			offset = tx.signature.length;
+			signature2 = null
+			tx.signature = signature1.toString("hex")
+			offset = tx.signature.length
 		}
 		else if(signature2){
-			tx.signSignature = signature1.toString("hex");
-			tx.signature = signature2.toString("hex");
-			offset = tx.signature.length+tx.signSignature.length;
+			tx.signSignature = signature1.toString("hex")
+			tx.signature = signature2.toString("hex")
+			offset = tx.signature.length+tx.signSignature.length
 		}
 	}
-	return offset;
+	return offset
 }
 
 function parseSignatures(hexString, tx, startOffset){
-	tx.signature = hexString.substring(startOffset);
-	if(tx.signature.length == 0) delete tx.signature;
+	tx.signature = hexString.substring(startOffset)
+	if(tx.signature.length == 0) delete tx.signature
 	else {
-		var length = parseInt("0x" + tx.signature.substring(2,4), 16) + 2;
-		tx.signature = hexString.substring(startOffset, startOffset + length*2);
-		tx.signSignature = hexString.substring(startOffset + length*2);
-		if(tx.signSignature.length == 0) delete tx.signSignature;
+		var length = parseInt("0x" + tx.signature.substring(2,4), 16) + 2
+		tx.signature = hexString.substring(startOffset, startOffset + length*2)
+		tx.signSignature = hexString.substring(startOffset + length*2)
+		if(tx.signSignature.length == 0) delete tx.signSignature
 	}
 }
 
 function getId(transaction) {
-	return crypto.createHash("sha256").update(getBytes(transaction)).digest().toString("hex");
+	return crypto.createHash("sha256").update(getBytes(transaction)).digest().toString("hex")
 }
 
 function getHash(transaction, skipSignature, skipSecondSignature) {
-	return crypto.createHash("sha256").update(getBytes(transaction, skipSignature, skipSecondSignature)).digest();
+	return crypto.createHash("sha256").update(getBytes(transaction, skipSignature, skipSecondSignature)).digest()
 }
 
 function getFee(transaction) {
 	switch (transaction.type) {
 		case 0: // Normal
-			return 0.1 * fixedPoint;
+			return 0.1 * fixedPoint
 
 		case 1: // Signature
-			return 100 * fixedPoint;
+			return 100 * fixedPoint
 
 		case 2: // Delegate
-			return 10000 * fixedPoint;
+			return 10000 * fixedPoint
 
 		case 3: // Vote
-			return 1 * fixedPoint;
+			return 1 * fixedPoint
 	}
 }
 
 function sign(transaction, keys) {
-	var hash = getHash(transaction, true, true);
+	var hash = getHash(transaction, true, true)
 
-	var signature = keys.sign(hash).toDER().toString("hex");
+	var signature = keys.sign(hash).toDER().toString("hex")
 
 	if (!transaction.signature) {
-		transaction.signature = signature;
+		transaction.signature = signature
 	}
-	return signature;
+	return signature
 
 }
 
 function secondSign(transaction, keys) {
-	var hash = getHash(transaction, false, true);
+	var hash = getHash(transaction, false, true)
 
-	var signature = keys.sign(hash).toDER().toString("hex");
+	var signature = keys.sign(hash).toDER().toString("hex")
 
 	if (!transaction.signSignature) {
-		transaction.signSignature = signature;
+		transaction.signSignature = signature
 	}
-	return signature;
+	return signature
 }
 
 function verify(transaction, network) {
-	network = network || networks.ark;
+	network = network || networks.ark
 
-	var hash = getHash(transaction, true, true);
+	var hash = getHash(transaction, true, true)
 
-	var signatureBuffer = new Buffer(transaction.signature, "hex");
-	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
-	var ecpair = ECPair.fromPublicKeyBuffer(senderPublicKeyBuffer, network);
-	var ecsignature = ECSignature.fromDER(signatureBuffer);
-	var res = ecpair.verify(hash, ecsignature);
+	var signatureBuffer = new Buffer(transaction.signature, "hex")
+	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex")
+	var ecpair = ECPair.fromPublicKeyBuffer(senderPublicKeyBuffer, network)
+	var ecsignature = ECSignature.fromDER(signatureBuffer)
+	var res = ecpair.verify(hash, ecsignature)
 
-	return res;
+	return res
 }
 
 function verifySecondSignature(transaction, publicKey, network) {
-	network = network || networks.ark;
+	network = network || networks.ark
 
-	var hash = getHash(transaction, false, true);
+	var hash = getHash(transaction, false, true)
 
-	var signSignatureBuffer = new Buffer(transaction.signSignature, "hex");
-	var publicKeyBuffer = new Buffer(publicKey, "hex");
-	var ecpair = ECPair.fromPublicKeyBuffer(publicKeyBuffer, network);
-	var ecsignature = ECSignature.fromDER(signSignatureBuffer);
-	var res = ecpair.verify(hash, ecsignature);
+	var signSignatureBuffer = new Buffer(transaction.signSignature, "hex")
+	var publicKeyBuffer = new Buffer(publicKey, "hex")
+	var ecpair = ECPair.fromPublicKeyBuffer(publicKeyBuffer, network)
+	var ecsignature = ECSignature.fromDER(signSignatureBuffer)
+	var res = ecpair.verify(hash, ecsignature)
 
-	return res;
+	return res
 }
 
 function getKeys(secret, network) {
-	var ecpair = ECPair.fromSeed(secret, network || networks.ark);
+	var ecpair = ECPair.fromSeed(secret, network || networks.ark)
 
-	ecpair.publicKey = ecpair.getPublicKeyBuffer().toString("hex");
-	ecpair.privateKey = '';
+	ecpair.publicKey = ecpair.getPublicKeyBuffer().toString("hex")
+	ecpair.privateKey = ''
 
-	return ecpair;
+	return ecpair
 }
 
 function getAddress(publicKey, version){
 	if(!version){
-		version = networkVersion;
+		version = networkVersion
 	}
-	var buffer = crypto_utils.ripemd160(new Buffer(publicKey,'hex'));
+	var buffer = crypto_utils.ripemd160(new Buffer(publicKey,'hex'))
 
-	var payload = new Buffer(21);
-	payload.writeUInt8(version, 0);
-	buffer.copy(payload, 1);
+	var payload = new Buffer(21)
+	payload.writeUInt8(version, 0)
+	buffer.copy(payload, 1)
 
-	return bs58check.encode(payload);
+	return bs58check.encode(payload)
 }
 
 function setNetworkVersion(version){
-	networkVersion = version;
+	networkVersion = version
 }
 
 function getNetworkVersion(){
-	return networkVersion;
+	return networkVersion
 }
 
 function validateAddress(address, version){
 	if(!version){
-		version = networkVersion;
+		version = networkVersion
 	}
 	try {
-		var decode = bs58check.decode(address);
-		return decode[0] == version;
+		var decode = bs58check.decode(address)
+		return decode[0] == version
 	} catch(e){
-		return false;
+		return false
 	}
 }
 

--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -7,12 +7,10 @@ var networks = require("../networks.js")
 var bs58check = require('bs58check')
 
 if (typeof Buffer === "undefined") {
-	Buffer = require("buffer/").Buffer;
+	Buffer = require("buffer/").Buffer; // eslint-disable-line no-global-assign
 }
 
 var ByteBuffer = require("bytebuffer");
-var bignum = require("browserify-bignum");
-
 
 var fixedPoint = Math.pow(10, 8);
 // default is ark mainnet
@@ -27,7 +25,7 @@ function getSignatureBytes(signature) {
 	}
 
 	bb.flip();
-	return new Uint8Array(bb.toArrayBuffer());
+	return new Uint8Array(bb.toArrayBuffer()); // eslint-disable-line no-undef
 }
 
 function getBytes(transaction, skipSignature, skipSecondSignature) {
@@ -71,22 +69,22 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 
 	}
 
-	var bb = new ByteBuffer(1 + 4 + 32 + 8 + 8 + 21 + 64 + 64 + 64 + assetSize, true);
+	bb = new ByteBuffer(1 + 4 + 32 + 8 + 8 + 21 + 64 + 64 + 64 + assetSize, true);
 	bb.writeByte(transaction.type);
 	bb.writeInt(transaction.timestamp);
 
 	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
-	for (var i = 0; i < senderPublicKeyBuffer.length; i++) {
+	for (i = 0; i < senderPublicKeyBuffer.length; i++) {
 		bb.writeByte(senderPublicKeyBuffer[i]);
 	}
 
 	if (transaction.recipientId) {
 		var recipient = bs58check.decode(transaction.recipientId);
-		for (var i = 0; i < recipient.length; i++) {
+		for (i = 0; i < recipient.length; i++) {
 			bb.writeByte(recipient[i]);
 		}
 	} else {
-		for (var i = 0; i < 21; i++) {
+		for (i = 0; i < 21; i++) {
 			bb.writeByte(0);
 		}
 	}
@@ -102,8 +100,8 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 		}
 	}
 	else if (transaction.vendorField) {
-		var vf = new Buffer(transaction.vendorField);
-		var fillstart=vf.length;
+		vf = new Buffer(transaction.vendorField);
+		fillstart=vf.length;
 		for (i = 0; i < fillstart; i++) {
 			bb.writeByte(vf[i]);
 		}
@@ -121,30 +119,30 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 	bb.writeLong(transaction.fee);
 
 	if (assetSize > 0) {
-		for (var i = 0; i < assetSize; i++) {
+		for (i = 0; i < assetSize; i++) {
 			bb.writeByte(assetBytes[i]);
 		}
 	}
 
 	if (!skipSignature && transaction.signature) {
 		var signatureBuffer = new Buffer(transaction.signature, "hex");
-		for (var i = 0; i < signatureBuffer.length; i++) {
+		for (i = 0; i < signatureBuffer.length; i++) {
 			bb.writeByte(signatureBuffer[i]);
 		}
 	}
 
 	if (!skipSecondSignature && transaction.signSignature) {
 		var signSignatureBuffer = new Buffer(transaction.signSignature, "hex");
-		for (var i = 0; i < signSignatureBuffer.length; i++) {
+		for (i = 0; i < signSignatureBuffer.length; i++) {
 			bb.writeByte(signSignatureBuffer[i]);
 		}
 	}
 
 	bb.flip();
-	var arrayBuffer = new Uint8Array(bb.toArrayBuffer());
+	var arrayBuffer = new Uint8Array(bb.toArrayBuffer()); // eslint-disable-line no-undef
 	var buffer = [];
 
-	for (var i = 0; i < arrayBuffer.length; i++) {
+	for (i = 0; i < arrayBuffer.length; i++) {
 		buffer[i] = arrayBuffer[i];
 	}
 
@@ -176,7 +174,7 @@ function fromBytes(hexString){
 	else if(tx.type == 2){ // delegate registration
 		delete tx.recipientId;
 		// Impossible to assess size of delegate asset, trying to grab signature and derive delegate asset
-		var offset = findAndParseSignatures(hexString, tx);
+		offset = findAndParseSignatures(hexString, tx);
 
 		tx.asset = {
 			delegate: {
@@ -193,7 +191,7 @@ function fromBytes(hexString){
 	}
 	else if(tx.type == 4){ // multisignature creation
 		delete tx.recipientId;
-		var offset = findAndParseSignatures(hexString, tx);
+		offset = findAndParseSignatures(hexString, tx);
 		var buffer = new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex")
 		tx.asset = {
 			multisignature: {}
@@ -212,7 +210,7 @@ function fromBytes(hexString){
 		delete tx.recipientId;
 		parseSignatures(hexString, tx, 76+42+128+32);
 	}
-	console.log(tx);
+	//console.log(tx);
 	return tx;
 }
 
@@ -236,10 +234,10 @@ function findAndParseSignatures(hexString, tx){
 		offset = 0;
 		signature1 = null;
 	}
-	else {
+	else {
 		found = false;
 		offset = signature1.length*2;
-		var signature2 = new Buffer(hexString.substring(hexString.length-offset-146, hexString.length-offset), "hex");
+		signature2 = new Buffer(hexString.substring(hexString.length-offset-146, hexString.length-offset), "hex");
 		while(!found && signature2.length > 8){
 			if(signature2[0] != 0x30){
 				signature2 = signature2.slice(1);
@@ -288,19 +286,15 @@ function getFee(transaction) {
 	switch (transaction.type) {
 		case 0: // Normal
 			return 0.1 * fixedPoint;
-			break;
 
 		case 1: // Signature
 			return 100 * fixedPoint;
-			break;
 
 		case 2: // Delegate
 			return 10000 * fixedPoint;
-			break;
 
 		case 3: // Vote
 			return 1 * fixedPoint;
-			break;
 	}
 }
 

--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -214,7 +214,6 @@ function fromBytes(hexString){
 		delete tx.recipientId;
 		parseSignatures(hexString, tx, 76+42+128+32);
 	}
-	//console.log(tx);
 	return tx;
 }
 

--- a/lib/transactions/delegate.js
+++ b/lib/transactions/delegate.js
@@ -1,18 +1,18 @@
 var crypto = require("./crypto.js"),
     constants = require("../constants.js"),
-    slots = require("../time/slots.js");
+    slots = require("../time/slots.js")
 
 function createDelegate(secret, username, secondSecret) {
-	if (!secret || !username) return false;
+	if (!secret || !username) return false
 
-	var keys = secret;
+	var keys = secret
 
 	if (!crypto.isECPair(secret)) {
-		keys = crypto.getKeys(secret);
+		keys = crypto.getKeys(secret)
 	}
 
 	if (!keys.publicKey) {
-		throw new Error("Invalid public key");
+		throw new Error("Invalid public key")
 	}
 
 	var transaction = {
@@ -28,20 +28,20 @@ function createDelegate(secret, username, secondSecret) {
 				publicKey: keys.publicKey
 			}
 		}
-	};
-
-	crypto.sign(transaction, keys);
-
-	if (secondSecret) {
-		var secondKeys = secondSecret;
-		if (!crypto.isECPair(secondSecret)) {
-			secondKeys = crypto.getKeys(secondSecret);
-		}
-		crypto.secondSign(transaction, secondKeys);
 	}
 
-	transaction.id = crypto.getId(transaction);
-	return transaction;
+	crypto.sign(transaction, keys)
+
+	if (secondSecret) {
+		var secondKeys = secondSecret
+		if (!crypto.isECPair(secondSecret)) {
+			secondKeys = crypto.getKeys(secondSecret)
+		}
+		crypto.secondSign(transaction, secondKeys)
+	}
+
+	transaction.id = crypto.getId(transaction)
+	return transaction
 }
 
 module.exports = {

--- a/lib/transactions/ipfs.js
+++ b/lib/transactions/ipfs.js
@@ -12,7 +12,7 @@ function createHashRegistration(ipfshash, secret, secondSecret) {
 	};
 
   transaction.vendorFieldHex = new Buffer(ipfshash,"utf8").toString("hex");
-  //filling with 0x00
+  // filling with 0x00
   while(transaction.vendorFieldHex.length < 128){
     transaction.vendorFieldHex = "00"+transaction.vendorFieldHex;
   }

--- a/lib/transactions/ipfs.js
+++ b/lib/transactions/ipfs.js
@@ -1,9 +1,9 @@
 var crypto = require("./crypto.js"),
     constants = require("../constants.js"),
-    slots = require("../time/slots.js");
+    slots = require("../time/slots.js")
 
 function createHashRegistration(ipfshash, secret, secondSecret) {
-	if (!ipfshash || !secret) return false;
+	if (!ipfshash || !secret) return false
 
 	var transaction = {
 		type: 5,
@@ -11,38 +11,38 @@ function createHashRegistration(ipfshash, secret, secondSecret) {
 		fee: constants.fees.send,
 		timestamp: slots.getTime(),
 		asset: {}
-	};
-
-  transaction.vendorFieldHex = new Buffer(ipfshash,"utf8").toString("hex");
-  // filling with 0x00
-  while(transaction.vendorFieldHex.length < 128){
-    transaction.vendorFieldHex = "00"+transaction.vendorFieldHex;
 	}
 
-	var keys = secret;
+  transaction.vendorFieldHex = new Buffer(ipfshash,"utf8").toString("hex")
+  // filling with 0x00
+  while(transaction.vendorFieldHex.length < 128){
+    transaction.vendorFieldHex = "00"+transaction.vendorFieldHex
+	}
+
+	var keys = secret
 
 	if (!crypto.isECPair(secret)) {
-		keys = crypto.getKeys(secret);
+		keys = crypto.getKeys(secret)
 	}
 
 	if (!keys.publicKey) {
-		throw new Error("Invalid public key");
+		throw new Error("Invalid public key")
 	}
 
-	transaction.senderPublicKey = keys.publicKey;
+	transaction.senderPublicKey = keys.publicKey
 
-	crypto.sign(transaction, keys);
+	crypto.sign(transaction, keys)
 
 	if (secondSecret) {
-		var secondKeys = secondSecret;
+		var secondKeys = secondSecret
 		if (!crypto.isECPair(secondSecret)) {
-			secondKeys = crypto.getKeys(secondSecret);
+			secondKeys = crypto.getKeys(secondSecret)
 		}
-		crypto.secondSign(transaction, secondKeys);
+		crypto.secondSign(transaction, secondKeys)
 	}
 
-	transaction.id = crypto.getId(transaction);
-	return transaction;
+	transaction.id = crypto.getId(transaction)
+	return transaction
 }
 
 module.exports = {

--- a/lib/transactions/multisignature.js
+++ b/lib/transactions/multisignature.js
@@ -1,28 +1,28 @@
 var crypto = require("./crypto.js"),
     constants = require("../constants.js"),
-    slots = require("../time/slots.js");
+    slots = require("../time/slots.js")
 
 function signTransaction(trs, secret) {
-	if (!trs || !secret) return false;
+	if (!trs || !secret) return false
 
-	var keys = secret;
+	var keys = secret
 
 	if (!crypto.isECPair(secret)) {
-		keys = crypto.getKeys(secret);
+		keys = crypto.getKeys(secret)
 	}
 
-	var signature = crypto.sign(trs, keys);
+	var signature = crypto.sign(trs, keys)
 
-	return signature;
+	return signature
 }
 
 function createMultisignature(secret, secondSecret, keysgroup, lifetime, min) {
-	if (!secret || !keysgroup || !lifetime || !min) return false;
+	if (!secret || !keysgroup || !lifetime || !min) return false
 
-	var keys = secret;
+	var keys = secret
 
 	if (!crypto.isECPair(secret)) {
-		keys = crypto.getKeys(secret);
+		keys = crypto.getKeys(secret)
 	}
 
 	var transaction = {
@@ -39,20 +39,20 @@ function createMultisignature(secret, secondSecret, keysgroup, lifetime, min) {
 				keysgroup: keysgroup
 			}
 		}
-	};
-
-	crypto.sign(transaction, keys);
-
-	if (secondSecret) {
-		var secondKeys = secondSecret;
-		if (!crypto.isECPair(secondSecret)) {
-			secondKeys = crypto.getKeys(secondSecret);
-		}
-		crypto.secondSign(transaction, secondKeys);
 	}
 
-	transaction.id = crypto.getId(transaction);
-	return transaction;
+	crypto.sign(transaction, keys)
+
+	if (secondSecret) {
+		var secondKeys = secondSecret
+		if (!crypto.isECPair(secondSecret)) {
+			secondKeys = crypto.getKeys(secondSecret)
+		}
+		crypto.secondSign(transaction, secondKeys)
+	}
+
+	transaction.id = crypto.getId(transaction)
+	return transaction
 }
 
 module.exports = {

--- a/lib/transactions/signature.js
+++ b/lib/transactions/signature.js
@@ -1,31 +1,31 @@
 var crypto = require("./crypto.js"),
     constants = require("../constants.js"),
-    slots = require("../time/slots.js");
+    slots = require("../time/slots.js")
 
 function newSignature(secondSecret) {
-	var keys = crypto.getKeys(secondSecret);
+	var keys = crypto.getKeys(secondSecret)
 
 	var signature = {
 		publicKey: keys.publicKey
-	};
+	}
 
-	return signature;
+	return signature
 }
 
 function createSignature(secret, secondSecret) {
-	if (!secret || !secondSecret) return false;
+	if (!secret || !secondSecret) return false
 
-	var keys = secret;
+	var keys = secret
 
 	if (!crypto.isECPair(secret)) {
-		keys = crypto.getKeys(secret);
+		keys = crypto.getKeys(secret)
 	}
 
 	if (!keys.publicKey) {
-    throw new Error("Invalid public key");
+    throw new Error("Invalid public key")
   }
 
-	var signature = newSignature(secondSecret);
+	var signature = newSignature(secondSecret)
 	var transaction = {
 		type: 1,
 		amount: 0,
@@ -36,12 +36,12 @@ function createSignature(secret, secondSecret) {
 		asset: {
 			signature: signature
 		}
-	};
+	}
 
-	crypto.sign(transaction, keys);
-	transaction.id = crypto.getId(transaction);
+	crypto.sign(transaction, keys)
+	transaction.id = crypto.getId(transaction)
 
-	return transaction;
+	return transaction
 }
 
 module.exports = {

--- a/lib/transactions/transaction.js
+++ b/lib/transactions/transaction.js
@@ -1,22 +1,22 @@
 var crypto = require("./crypto.js"),
     constants = require("../constants.js"),
-    slots = require("../time/slots.js");
+    slots = require("../time/slots.js")
 
 function createTransaction(recipientId, amount, vendorField, secret, secondSecret) {
-	if (!recipientId || !amount || !secret) return false;
+	if (!recipientId || !amount || !secret) return false
 
   if(!crypto.validateAddress(recipientId)){
-    throw new Error("Wrong recipientId");
+    throw new Error("Wrong recipientId")
 	}
 
-	var keys = secret;
+	var keys = secret
 
 	if (!crypto.isECPair(secret)) {
-		keys = crypto.getKeys(secret);
+		keys = crypto.getKeys(secret)
 	}
 
   if (!keys.publicKey) {
-    throw new Error("Invalid public key");
+    throw new Error("Invalid public key")
   }
 
 	var transaction = {
@@ -26,29 +26,29 @@ function createTransaction(recipientId, amount, vendorField, secret, secondSecre
 		recipientId: recipientId,
 		timestamp: slots.getTime(),
 		asset: {}
-	};
+	}
 
   if(vendorField){
-    transaction.vendorField=vendorField;
+    transaction.vendorField=vendorField
     if(transaction.vendorField.length > 64){
-			return null;
+			return null
 		}
   }
 
-	transaction.senderPublicKey = keys.publicKey;
+	transaction.senderPublicKey = keys.publicKey
 
-	crypto.sign(transaction, keys);
+	crypto.sign(transaction, keys)
 
 	if (secondSecret) {
-		var secondKeys = secondSecret;
+		var secondKeys = secondSecret
 		if (!crypto.isECPair(secondSecret)) {
-			secondKeys = crypto.getKeys(secondSecret);
+			secondKeys = crypto.getKeys(secondSecret)
 		}
-		crypto.secondSign(transaction, secondKeys);
+		crypto.secondSign(transaction, secondKeys)
 	}
 
-	transaction.id = crypto.getId(transaction);
-	return transaction;
+	transaction.id = crypto.getId(transaction)
+	return transaction
 }
 
 module.exports = {

--- a/lib/transactions/vote.js
+++ b/lib/transactions/vote.js
@@ -1,18 +1,18 @@
 var crypto = require("./crypto.js"),
     constants = require("../constants.js"),
-    slots = require("../time/slots.js");
+    slots = require("../time/slots.js")
 
 function createVote(secret, delegates, secondSecret) {
-	if (!secret || !Array.isArray(delegates)) return;
+	if (!secret || !Array.isArray(delegates)) return
 
-	var keys = secret;
+	var keys = secret
 
 	if (!crypto.isECPair(secret)) {
-		keys = crypto.getKeys(secret);
+		keys = crypto.getKeys(secret)
   }
 
   if (!keys.publicKey) {
-    throw new Error("Invalid public key");
+    throw new Error("Invalid public key")
   }
 
 	var transaction = {
@@ -25,21 +25,21 @@ function createVote(secret, delegates, secondSecret) {
 		asset: {
 			votes: delegates
 		}
-	};
-
-	crypto.sign(transaction, keys);
-
-	if (secondSecret) {
-		var secondKeys = secondSecret;
-		if (!crypto.isECPair(secondSecret)) {
-			secondKeys = crypto.getKeys(secondSecret);
-		}
-		crypto.secondSign(transaction, secondKeys);
 	}
 
-	transaction.id = crypto.getId(transaction);
+	crypto.sign(transaction, keys)
 
-	return transaction;
+	if (secondSecret) {
+		var secondKeys = secondSecret
+		if (!crypto.isECPair(secondSecret)) {
+			secondKeys = crypto.getKeys(secondSecret)
+		}
+		crypto.secondSign(transaction, secondKeys)
+	}
+
+	transaction.id = crypto.getId(transaction)
+
+	return transaction
 }
 
 module.exports = {

--- a/lib/v2/transactions/crypto.js
+++ b/lib/v2/transactions/crypto.js
@@ -1,121 +1,121 @@
-var crypto = require("crypto");
-var crypto_utils = require("../../crypto.js");
-var ECPair = require("../../ecpair.js");
-var ECSignature = require("../../ecsignature.js");
+var crypto = require("crypto")
+var crypto_utils = require("../../crypto.js")
+var ECPair = require("../../ecpair.js")
+var ECSignature = require("../../ecsignature.js")
 var networks = require("../../networks.js")
 
 var bs58check = require('bs58check')
 
 if (typeof Buffer === "undefined") {
-	Buffer = require("buffer/").Buffer; // eslint-disable-line no-global-assign
+	Buffer = require("buffer/").Buffer // eslint-disable-line no-global-assign
 }
 
-var ByteBuffer = require("bytebuffer");
+var ByteBuffer = require("bytebuffer")
 
 
-var fixedPoint = Math.pow(10, 8);
+var fixedPoint = Math.pow(10, 8)
 // default is ark mainnet
-var networkVersion = 0x17;
+var networkVersion = 0x17
 
 
 function getBytes(transaction) {
-	var bb = new ByteBuffer(512, true);
-	bb.writeByte(0xff); // fill, to disambiguate from v1
-	bb.writeByte(transaction.version); // version 2
-	bb.writeByte(transaction.network); // ark = 0x17, devnet = 0x30
-	bb.writeByte(transaction.type);
-	bb.writeInt(transaction.timestamp);
-	bb.append(transaction.senderPublicKey, "hex");
-	bb.writeLong(transaction.fee);
+	var bb = new ByteBuffer(512, true)
+	bb.writeByte(0xff) // fill, to disambiguate from v1
+	bb.writeByte(transaction.version) // version 2
+	bb.writeByte(transaction.network) // ark = 0x17, devnet = 0x30
+	bb.writeByte(transaction.type)
+	bb.writeInt(transaction.timestamp)
+	bb.append(transaction.senderPublicKey, "hex")
+	bb.writeLong(transaction.fee)
 	if(transaction.vendorFieldHex){
-		bb.writeByte(transaction.vendorFieldHex.length/2);
-		bb.append(transaction.vendorFieldHex, "hex");
+		bb.writeByte(transaction.vendorFieldHex.length/2)
+		bb.append(transaction.vendorFieldHex, "hex")
 	}
 	else {
-		bb.writeByte(0x00);
+		bb.writeByte(0x00)
 	}
 
 	switch (transaction.type) {
 		case 0: // Transfer
-			bb.writeLong(transaction.amount);
-			bb.writeInt(transaction.expiration);
-			bb.append(bs58check.decode(transaction.recipientId));
-			break;
+			bb.writeLong(transaction.amount)
+			bb.writeInt(transaction.expiration)
+			bb.append(bs58check.decode(transaction.recipientId))
+			break
 
 		case 1: // Signature
-			bb.append(transaction.asset.signature.publicKey,"hex");
-			break;
+			bb.append(transaction.asset.signature.publicKey,"hex")
+			break
 
 		case 2: // Delegate
-			var delegateBytes = new Buffer(transaction.asset.delegate.username, "utf8");
-			bb.writeByte(delegateBytes.length/2);
-			bb.append(delegateBytes,"hex");
-			break;
+			var delegateBytes = new Buffer(transaction.asset.delegate.username, "utf8")
+			bb.writeByte(delegateBytes.length/2)
+			bb.append(delegateBytes,"hex")
+			break
 
 		case 3: // Vote
 			var voteBytes = transaction.asset.votes.map(function(vote){
-				return (vote[0] == "+" ? "01" : "00") + vote.slice(1);
-			}).join("");
-			bb.writeByte(transaction.asset.votes.length);
-			bb.append(voteBytes,"hex");
-			break;
+				return (vote[0] == "+" ? "01" : "00") + vote.slice(1)
+			}).join("")
+			bb.writeByte(transaction.asset.votes.length)
+			bb.append(voteBytes,"hex")
+			break
 
 		case 4: // Multi-Signature
-			var keysgroupBuffer = new Buffer(transaction.asset.multisignature.keysgroup.join(""), "hex");
-			bb.writeByte(transaction.asset.multisignature.min);
-			bb.writeByte(transaction.asset.multisignature.keysgroup.length);
-			bb.writeByte(transaction.asset.multisignature.lifetime);
-			bb.append(keysgroupBuffer,"hex");
-			break;
+			var keysgroupBuffer = new Buffer(transaction.asset.multisignature.keysgroup.join(""), "hex")
+			bb.writeByte(transaction.asset.multisignature.min)
+			bb.writeByte(transaction.asset.multisignature.keysgroup.length)
+			bb.writeByte(transaction.asset.multisignature.lifetime)
+			bb.append(keysgroupBuffer,"hex")
+			break
 
 		case 5: // IPFS
-			bb.writeByte(transaction.asset.ipfs.dag.length/2);
-			bb.append(transaction.asset.ipfs.dag,"hex");
-			break;
+			bb.writeByte(transaction.asset.ipfs.dag.length/2)
+			bb.append(transaction.asset.ipfs.dag,"hex")
+			break
 
 		case 6: // timelock transfer
-			bb.writeLong(transaction.amount);
-			bb.writeByte(transaction.timelocktype);
-			bb.writeInt(transaction.timelock);
-			bb.append(bs58check.decode(transaction.recipientId));
-			break;
+			bb.writeLong(transaction.amount)
+			bb.writeByte(transaction.timelocktype)
+			bb.writeInt(transaction.timelock)
+			bb.append(bs58check.decode(transaction.recipientId))
+			break
 
 		case 7: // multipayment
-			bb.writeInt(transaction.asset.payments.length);
+			bb.writeInt(transaction.asset.payments.length)
 			transaction.asset.payments.forEach(function(p) {
-				bb.writeLong(p.amount);
-				bb.append(bs58check.decode(p.recipientId));
-			});
-			break;
+				bb.writeLong(p.amount)
+				bb.append(bs58check.decode(p.recipientId))
+			})
+			break
 
 		case 8: // delegate resignation - empty payload
-			break;
+			break
 	}
-	bb.flip();
-	return bb.toBuffer();
+	bb.flip()
+	return bb.toBuffer()
 }
 
 function fromBytes(hexString){
-	var tx={};
-	var buf = new Buffer(hexString, "hex");
-	tx.version = buf.readInt8(1) & 0xff;
-	tx.network = buf.readInt8(2) & 0xff;
-	tx.type = buf.readInt8(3) & 0xff;
-	tx.timestamp = buf.readUInt32LE(4);
-	tx.senderPublicKey = hexString.substring(16,16+33*2);
-	tx.fee = buf.readUInt32LE(41);
-	var vflength = buf.readInt8(41+8) & 0xff;
+	var tx={}
+	var buf = new Buffer(hexString, "hex")
+	tx.version = buf.readInt8(1) & 0xff
+	tx.network = buf.readInt8(2) & 0xff
+	tx.type = buf.readInt8(3) & 0xff
+	tx.timestamp = buf.readUInt32LE(4)
+	tx.senderPublicKey = hexString.substring(16,16+33*2)
+	tx.fee = buf.readUInt32LE(41)
+	var vflength = buf.readInt8(41+8) & 0xff
 	if(vflength > 0){
-		tx.vendorFieldHex=hexString.substring((41+8+1)*2,(41+8+1)*2+vflength*2);
+		tx.vendorFieldHex=hexString.substring((41+8+1)*2,(41+8+1)*2+vflength*2)
 	}
 
-	var assetOffset = (41+8+1)*2+vflength*2;
+	var assetOffset = (41+8+1)*2+vflength*2
 
 	if(tx.type == 0){ // transfer
-		tx.amount = buf.readUInt32LE(assetOffset/2);
-		tx.expiration = buf.readUInt32LE(assetOffset/2+8);
-		tx.recipientId = bs58check.encode(buf.slice(assetOffset/2+12,assetOffset/2+12+21));
-		parseSignatures(hexString, tx, assetOffset+(21+12)*2);
+		tx.amount = buf.readUInt32LE(assetOffset/2)
+		tx.expiration = buf.readUInt32LE(assetOffset/2+8)
+		tx.recipientId = bs58check.encode(buf.slice(assetOffset/2+12,assetOffset/2+12+21))
+		parseSignatures(hexString, tx, assetOffset+(21+12)*2)
 	}
 	else if(tx.type == 1){ // second signature registration
 		tx.asset = {
@@ -123,200 +123,200 @@ function fromBytes(hexString){
 				publicKey : hexString.substring(assetOffset,assetOffset+66)
 			}
 		}
-		parseSignatures(hexString, tx, assetOffset+66);
+		parseSignatures(hexString, tx, assetOffset+66)
 	}
 	else if(tx.type == 2){ // delegate registration
-		var usernamelength = buf.readInt8(assetOffset/2) & 0xff;
+		var usernamelength = buf.readInt8(assetOffset/2) & 0xff
 
 		tx.asset = {
 			delegate: {
 				username: buf.slice(assetOffset/2+1, assetOffset/2+1 + usernamelength).toString("utf8")
 			}
-		};
-		parseSignatures(hexString, tx, assetOffset + (usernamelength+1)*2);
+		}
+		parseSignatures(hexString, tx, assetOffset + (usernamelength+1)*2)
 	}
 	else if(tx.type == 3){ // vote
-		var votelength = buf.readInt8(assetOffset/2) & 0xff;
-		tx.asset = {votes:[]};
-		var vote;
+		var votelength = buf.readInt8(assetOffset/2) & 0xff
+		tx.asset = {votes:[]}
+		var vote
 		for(var i = 0; i<votelength; i++){
-			vote = hexString.substring(assetOffset + 2 + i*2*34, assetOffset + 2 + (i+1)*2*34);
-			vote = (vote[1] == "1" ? "+" : "-") + vote.slice(2);
-			tx.asset.votes.push(vote);
+			vote = hexString.substring(assetOffset + 2 + i*2*34, assetOffset + 2 + (i+1)*2*34)
+			vote = (vote[1] == "1" ? "+" : "-") + vote.slice(2)
+			tx.asset.votes.push(vote)
 		}
-		parseSignatures(hexString, tx, assetOffset + 2 + votelength*34*2);
+		parseSignatures(hexString, tx, assetOffset + 2 + votelength*34*2)
 	}
 	else if(tx.type == 4){ // multisignature creation
 		var buffer = new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex")
 		tx.asset = {
 			multisignature: {}
 		}
-		tx.asset.multisignature.min = buffer.readInt8(assetOffset/2) & 0xff;
-		var num = buffer.readInt8(assetOffset/2+1) & 0xff;
-		tx.asset.multisignature.lifetime = buffer.readInt8(assetOffset/2+2) & 0xff;
-		tx.asset.multisignature.keysgroup = [];
+		tx.asset.multisignature.min = buffer.readInt8(assetOffset/2) & 0xff
+		var num = buffer.readInt8(assetOffset/2+1) & 0xff
+		tx.asset.multisignature.lifetime = buffer.readInt8(assetOffset/2+2) & 0xff
+		tx.asset.multisignature.keysgroup = []
 		for(var index = 0; index < num; index++){
-			/*var key = */hexString.slice(assetOffset + 6 + index*66, assetOffset + 6 + (index+1)*66);
+			/*var key = */hexString.slice(assetOffset + 6 + index*66, assetOffset + 6 + (index+1)*66)
 		}
-		parseSignatures(hexString, tx, assetOffset + 6 + num*66);
+		parseSignatures(hexString, tx, assetOffset + 6 + num*66)
 	}
 	else if(tx.type == 5){ // ipfs
-		tx.asset = {};
-		var l = buf.readInt8(assetOffset/2) & 0xff;
-		tx.asset.dag = hexString.substring(assetOffset+2,assetOffset+2+l*2);
-		parseSignatures(hexString, tx, assetOffset+2+l*2);
+		tx.asset = {}
+		var l = buf.readInt8(assetOffset/2) & 0xff
+		tx.asset.dag = hexString.substring(assetOffset+2,assetOffset+2+l*2)
+		parseSignatures(hexString, tx, assetOffset+2+l*2)
 	}
 	else if(tx.type == 6){ // timelock
-		tx.amount = buf.readUInt32LE(assetOffset/2);
-		tx.timelocktype = buf.readInt8(assetOffset/2+8) & 0xff;
-		tx.timelock = buf.readUInt32LE(assetOffset/2+9);
-		tx.recipientId = bs58check.encode(buf.slice(assetOffset/2+13,assetOffset/2+13+21));
-		parseSignatures(hexString, tx, assetOffset+(21+13)*2);
+		tx.amount = buf.readUInt32LE(assetOffset/2)
+		tx.timelocktype = buf.readInt8(assetOffset/2+8) & 0xff
+		tx.timelock = buf.readUInt32LE(assetOffset/2+9)
+		tx.recipientId = bs58check.encode(buf.slice(assetOffset/2+13,assetOffset/2+13+21))
+		parseSignatures(hexString, tx, assetOffset+(21+13)*2)
 	}
 	else if(tx.type == 7){ // multipayment
 		tx.asset = {
 			payments: []
 		}
-		var total = buffer.readInt8(assetOffset/2) & 0xff;
-		var offset = assetOffset/2 + 1;
+		var total = buffer.readInt8(assetOffset/2) & 0xff
+		var offset = assetOffset/2 + 1
 		for(i = 0; i<total; i++){
-			var payment = {};
-			payment.amount = buf.readUInt32LE(offset);
-			payment.recipientId = bs58check.encode(buf.slice(offset+1,offset+1+21));
-			tx.asset.payments.push(payment);
-			offset += 22;
+			var payment = {}
+			payment.amount = buf.readUInt32LE(offset)
+			payment.recipientId = bs58check.encode(buf.slice(offset+1,offset+1+21))
+			tx.asset.payments.push(payment)
+			offset += 22
 		}
-		parseSignatures(hexString, tx, offset*2);
+		parseSignatures(hexString, tx, offset*2)
 	}
 	else if(tx.type == 8){ // delegate resignation
-		parseSignatures(hexString, tx, assetOffset);
+		parseSignatures(hexString, tx, assetOffset)
 	}
-	return tx;
+	return tx
 }
 
 function parseSignatures(hexString, tx, startOffset){
-	tx.signature = hexString.substring(startOffset);
-	if(tx.signature.length == 0) delete tx.signature;
+	tx.signature = hexString.substring(startOffset)
+	if(tx.signature.length == 0) delete tx.signature
 	else {
-		var length = parseInt("0x" + tx.signature.substring(2,4), 16) + 2;
-		tx.signature = hexString.substring(startOffset, startOffset + length*2);
-		tx.secondSignature = hexString.substring(startOffset + length*2);
-		if(tx.secondSignature.length == 0) delete tx.secondSignature;
+		var length = parseInt("0x" + tx.signature.substring(2,4), 16) + 2
+		tx.signature = hexString.substring(startOffset, startOffset + length*2)
+		tx.secondSignature = hexString.substring(startOffset + length*2)
+		if(tx.secondSignature.length == 0) delete tx.secondSignature
 	}
 }
 
 function getId(transaction) {
-	return getHash(transaction).toString("hex");
+	return getHash(transaction).toString("hex")
 }
 
 function getHash(transaction) {
-	return crypto.createHash("sha256").update(getBytes(transaction)).digest();
+	return crypto.createHash("sha256").update(getBytes(transaction)).digest()
 }
 
 function getFee(transaction) {
 	switch (transaction.type) {
 		case 0: // Normal
-			return 0.1 * fixedPoint;
+			return 0.1 * fixedPoint
 
 		case 1: // Signature
-			return 100 * fixedPoint;
+			return 100 * fixedPoint
 
 		case 2: // Delegate
-			return 10000 * fixedPoint;
+			return 10000 * fixedPoint
 
 		case 3: // Vote
-			return 1 * fixedPoint;
+			return 1 * fixedPoint
 	}
 }
 
 function sign(transaction, keys) {
-	var hash = getHash(transaction);
+	var hash = getHash(transaction)
 
-	var signature = keys.sign(hash).toDER().toString("hex");
+	var signature = keys.sign(hash).toDER().toString("hex")
 
 	if (!transaction.signature) {
-		transaction.signature = signature;
+		transaction.signature = signature
 	}
-	return signature;
+	return signature
 }
 
 function secondSign(transaction, keys) {
-	var hash = getHash(transaction);
+	var hash = getHash(transaction)
 
-	var signature = keys.sign(hash).toDER().toString("hex");
+	var signature = keys.sign(hash).toDER().toString("hex")
 
 	if (!transaction.secondSignature) {
-		transaction.secondSignature = signature;
+		transaction.secondSignature = signature
 	}
-	return signature;
+	return signature
 }
 
 function verify(transaction, network) {
-	network = network || networks.ark;
+	network = network || networks.ark
 
-	var hash = getHash(transaction);
+	var hash = getHash(transaction)
 
-	var signatureBuffer = new Buffer(transaction.signature, "hex");
-	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
-	var ecpair = ECPair.fromPublicKeyBuffer(senderPublicKeyBuffer, network);
-	var ecsignature = ECSignature.fromDER(signatureBuffer);
-	var res = ecpair.verify(hash, ecsignature);
+	var signatureBuffer = new Buffer(transaction.signature, "hex")
+	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex")
+	var ecpair = ECPair.fromPublicKeyBuffer(senderPublicKeyBuffer, network)
+	var ecsignature = ECSignature.fromDER(signatureBuffer)
+	var res = ecpair.verify(hash, ecsignature)
 
-	return res;
+	return res
 }
 
 function verifySecondSignature(transaction, publicKey, network) {
-	network = network || networks.ark;
+	network = network || networks.ark
 
-	var hash = getHash(transaction);
+	var hash = getHash(transaction)
 
-	var secondSignatureBuffer = new Buffer(transaction.secondSignature, "hex");
-	var publicKeyBuffer = new Buffer(publicKey, "hex");
-	var ecpair = ECPair.fromPublicKeyBuffer(publicKeyBuffer, network);
-	var ecsignature = ECSignature.fromDER(secondSignatureBuffer);
-	var res = ecpair.verify(hash, ecsignature);
+	var secondSignatureBuffer = new Buffer(transaction.secondSignature, "hex")
+	var publicKeyBuffer = new Buffer(publicKey, "hex")
+	var ecpair = ECPair.fromPublicKeyBuffer(publicKeyBuffer, network)
+	var ecsignature = ECSignature.fromDER(secondSignatureBuffer)
+	var res = ecpair.verify(hash, ecsignature)
 
-	return res;
+	return res
 }
 
 function getKeys(secret, network) {
-	var ecpair = ECPair.fromSeed(secret, network || networks.ark);
-	ecpair.publicKey = ecpair.getPublicKeyBuffer().toString("hex");
-	ecpair.privateKey = '';
+	var ecpair = ECPair.fromSeed(secret, network || networks.ark)
+	ecpair.publicKey = ecpair.getPublicKeyBuffer().toString("hex")
+	ecpair.privateKey = ''
 
-	return ecpair;
+	return ecpair
 }
 
 function getAddress(publicKey, version){
 	if(!version){
-		version = networkVersion;
+		version = networkVersion
 	}
-	var buffer = crypto_utils.ripemd160(new Buffer(publicKey,'hex'));
+	var buffer = crypto_utils.ripemd160(new Buffer(publicKey,'hex'))
 
-	var payload = new Buffer(21);
-	payload.writeUInt8(version, 0);
-	buffer.copy(payload, 1);
+	var payload = new Buffer(21)
+	payload.writeUInt8(version, 0)
+	buffer.copy(payload, 1)
 
-	return bs58check.encode(payload);
+	return bs58check.encode(payload)
 }
 
 function setNetworkVersion(version){
-	networkVersion = version;
+	networkVersion = version
 }
 
 function getNetworkVersion(){
-	return networkVersion;
+	return networkVersion
 }
 
 function validateAddress(address, version){
 	if(!version){
-		version = networkVersion;
+		version = networkVersion
 	}
 	try {
-		var decode = bs58check.decode(address);
-		return decode[0] == version;
+		var decode = bs58check.decode(address)
+		return decode[0] == version
 	} catch(e){
-		return false;
+		return false
 	}
 }
 

--- a/lib/v2/transactions/crypto.js
+++ b/lib/v2/transactions/crypto.js
@@ -7,7 +7,7 @@ var networks = require("../../networks.js")
 var bs58check = require('bs58check')
 
 if (typeof Buffer === "undefined") {
-	Buffer = require("buffer/").Buffer;
+	Buffer = require("buffer/").Buffer; // eslint-disable-line no-global-assign
 }
 
 var ByteBuffer = require("bytebuffer");
@@ -20,7 +20,7 @@ var networkVersion = 0x17;
 
 function getBytes(transaction) {
 	var bb = new ByteBuffer(512, true);
-	bb.writeByte(0xff); // fill, to disambiguate from v1 
+	bb.writeByte(0xff); // fill, to disambiguate from v1
 	bb.writeByte(transaction.version); // version 2
 	bb.writeByte(transaction.network); // ark = 0x17, devnet = 0x30
 	bb.writeByte(transaction.type);
@@ -72,8 +72,8 @@ function getBytes(transaction) {
 			bb.writeByte(transaction.asset.ipfs.dag.length/2);
 			bb.append(transaction.asset.ipfs.dag,"hex");
 			break;
-		
-		case 6: // timelock transfer 
+
+		case 6: // timelock transfer
 			bb.writeLong(transaction.amount);
 			bb.writeByte(transaction.timelocktype);
 			bb.writeInt(transaction.timelock);
@@ -110,7 +110,7 @@ function fromBytes(hexString){
 	}
 
 	var assetOffset = (41+8+1)*2+vflength*2;
-    
+
 	if(tx.type == 0){ // transfer
 		tx.amount = buf.readUInt32LE(assetOffset/2);
 		tx.expiration = buf.readUInt32LE(assetOffset/2+8);
@@ -147,6 +147,7 @@ function fromBytes(hexString){
 		parseSignatures(hexString, tx, assetOffset + 2 + votelength*34*2);
 	}
 	else if(tx.type == 4){ // multisignature creation
+		var buffer = new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex")
 		tx.asset = {
 			multisignature: {}
 		}
@@ -155,7 +156,7 @@ function fromBytes(hexString){
 		tx.asset.multisignature.lifetime = buffer.readInt8(assetOffset/2+2) & 0xff;
 		tx.asset.multisignature.keysgroup = [];
 		for(var index = 0; index < num; index++){
-			var key = hexString.slice(assetOffset + 6 + index*66, assetOffset + 6 + (index+1)*66);
+			/*var key = */hexString.slice(assetOffset + 6 + index*66, assetOffset + 6 + (index+1)*66);
 		}
 		parseSignatures(hexString, tx, assetOffset + 6 + num*66);
 	}
@@ -178,7 +179,7 @@ function fromBytes(hexString){
 		}
 		var total = buffer.readInt8(assetOffset/2) & 0xff;
 		var offset = assetOffset/2 + 1;
-		for(var i = 0; i<total; i++){
+		for(i = 0; i<total; i++){
 			var payment = {};
 			payment.amount = buf.readUInt32LE(offset);
 			payment.recipientId = bs58check.encode(buf.slice(offset+1,offset+1+21));
@@ -216,19 +217,15 @@ function getFee(transaction) {
 	switch (transaction.type) {
 		case 0: // Normal
 			return 0.1 * fixedPoint;
-			break;
 
 		case 1: // Signature
 			return 100 * fixedPoint;
-			break;
 
 		case 2: // Delegate
 			return 10000 * fixedPoint;
-			break;
 
 		case 3: // Vote
 			return 1 * fixedPoint;
-			break;
 	}
 }
 

--- a/lib/v2/transactions/transfer.js
+++ b/lib/v2/transactions/transfer.js
@@ -1,7 +1,7 @@
 var crypto = require("./crypto.js"),
     constants = require("../../constants.js"),
 		slots = require("../../time/slots.js");
-		
+
 function Transfer(){
 	this.id = null;
 	this.amount = 0;
@@ -40,7 +40,7 @@ Transfer.prototype.verify = function(){
 	return crypto.verify(this);
 }
 
-Transfer.prototype.secondSign = function(passphrase){
+Transfer.prototype.secondSign = function(passphrase, transaction){
 	var keys = crypto.getKeys(passphrase);
 	this.secondSignature = crypto.secondSign(transaction, keys);
 	return this;

--- a/lib/v2/transactions/transfer.js
+++ b/lib/v2/transactions/transfer.js
@@ -1,49 +1,49 @@
 var crypto = require("./crypto.js"),
     constants = require("../../constants.js"),
-		slots = require("../../time/slots.js");
+		slots = require("../../time/slots.js")
 
 function Transfer(){
-	this.id = null;
-	this.amount = 0;
-	this.fee = constants.fees.send;
-	this.timestamp = slots.getTime();
-	this.type = 0;
-	this.expiration = 15; //15 blocks, 120s
-	this.version = 0x02;
-	this.network = 0x17;
+	this.id = null
+	this.amount = 0
+	this.fee = constants.fees.send
+	this.timestamp = slots.getTime()
+	this.type = 0
+	this.expiration = 15 //15 blocks, 120s
+	this.version = 0x02
+	this.network = 0x17
 }
 
 Transfer.prototype.setNetwork = function(network){
-	this.network = network;
-	return this;
+	this.network = network
+	return this
 }
 
 Transfer.prototype.create = function(recipientId, amount){
-	this.amount = amount;
-	this.recipientId = recipientId;
-	return this;
+	this.amount = amount
+	this.recipientId = recipientId
+	return this
 }
 
 Transfer.prototype.setVendorField = function(data, type){
-	this.vendorFieldHex = new Buffer(data, type).toString("hex");
-	return this;
+	this.vendorFieldHex = new Buffer(data, type).toString("hex")
+	return this
 }
 
 Transfer.prototype.sign = function(passphrase){
-	var keys = crypto.getKeys(passphrase);
-	this.senderPublicKey = keys.publicKey;
-	this.signature = crypto.sign(this, keys);
-	return this;
+	var keys = crypto.getKeys(passphrase)
+	this.senderPublicKey = keys.publicKey
+	this.signature = crypto.sign(this, keys)
+	return this
 }
 
 Transfer.prototype.verify = function(){
-	return crypto.verify(this);
+	return crypto.verify(this)
 }
 
 Transfer.prototype.secondSign = function(passphrase, transaction){
-	var keys = crypto.getKeys(passphrase);
-	this.secondSignature = crypto.secondSign(transaction, keys);
-	return this;
+	var keys = crypto.getKeys(passphrase)
+	this.secondSignature = crypto.secondSign(transaction, keys)
+	return this
 }
 
 Transfer.prototype.serialise = function(){
@@ -52,8 +52,8 @@ Transfer.prototype.serialise = function(){
 		id: crypto.getId(this),
 		signature: this.signature,
 		secondSignature: this.secondSignature
-	};
+	}
 }
 
 
-module.exports = Transfer;
+module.exports = Transfer

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typeforce": "^1.10.3",
     "wif": "^2.0.4"
   },
-  "devDependencies": {,
+  "devDependencies": {
     "eslint": "^4.2.0",
     "mocha": "=3.1.0",
     "proxyquire": "^1.7.10",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "wif": "^2.0.4"
   },
   "devDependencies": {
-    "eslint": "^4.2.0",
+    "eslint": "^4.4.1",
     "proxyquire": "^1.7.10",
     "should": "=11.1.0",
     "sinon": "^1.17.7"

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,6 @@
+{
+    "extends": "../.eslintrc",
+    "env": {
+        "mocha": true
+    }
+}

--- a/test/ark.js
+++ b/test/ark.js
@@ -1,5 +1,4 @@
-var Buffer = require("buffer/").Buffer;
-var should = require("should");
+require("should");
 var ark = require("../index.js");
 
 describe("Ark JS", function () {

--- a/test/ark.js
+++ b/test/ark.js
@@ -1,22 +1,22 @@
-require("should");
-var ark = require("../index.js");
+require("should")
+var ark = require("../index.js")
 
 describe("Ark JS", function () {
 
 	it("should be ok", function () {
-		(ark).should.be.ok;
-	});
+		(ark).should.be.ok
+	})
 
 	it("should be object", function () {
-		(ark).should.be.type("object");
-	});
+		(ark).should.be.type("object")
+	})
 
 	it("should have properties", function () {
-		var properties = ["transaction", "signature", "vote", "delegate", "crypto"];
+		var properties = ["transaction", "signature", "vote", "delegate", "crypto"]
 
 		properties.forEach(function (property) {
-			(ark).should.have.property(property);
-		});
-	});
+			(ark).should.have.property(property)
+		})
+	})
 
-});
+})

--- a/test/crypto/index.js
+++ b/test/crypto/index.js
@@ -1,9 +1,9 @@
 /* eslint-disable max-len */
 
-require("should");
-var Buffer = require("buffer/").Buffer;
-var ark = require("../../index.js");
-var ECPair = require('../../lib/ecpair');
+require("should")
+var Buffer = require("buffer/").Buffer
+var ark = require("../../index.js")
+var ECPair = require('../../lib/ecpair')
 
 var ecdsa = require('../../lib/ecdsa')
 var ecurve = require('ecurve')
@@ -11,37 +11,37 @@ var curve = ecdsa.__curve
 
 describe("crypto.js", function () {
 
-  var crypto = ark.crypto;
+  var crypto = ark.crypto
 
   it("should be ok", function () {
-    (crypto).should.be.ok;
-  });
+    (crypto).should.be.ok
+  })
 
   it("should be object", function () {
-    (crypto).should.be.type("object");
-  });
+    (crypto).should.be.type("object")
+  })
 
   it("should has properties", function () {
     var properties = [
       "getBytes", "getHash", "getId", "getFee", "sign", "secondSign",
       "getKeys", "getAddress", "verify", "verifySecondSignature", "fixedPoint"
-    ];
+    ]
     properties.forEach(function (property) {
-      (crypto).should.have.property(property);
-    });
-  });
+      (crypto).should.have.property(property)
+    })
+  })
 
   describe("#getBytes", function () {
-    var getBytes = crypto.getBytes;
-    var bytes = null;
+    var getBytes = crypto.getBytes
+    var bytes = null
 
     it("should be ok", function () {
-      (getBytes).should.be.ok;
-    });
+      (getBytes).should.be.ok
+    })
 
     it("should be a function", function () {
-      (getBytes).should.be.type("function");
-    });
+      (getBytes).should.be.type("function")
+    })
 
     it("should return Buffer of simply transaction and buffer must be 202 length", function () {
       var transaction = {
@@ -54,13 +54,13 @@ describe("crypto.js", function () {
         senderPublicKey: "5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09",
         signature: "618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a",
         id: "13987348420913138422"
-      };
+      }
 
       bytes = getBytes(transaction);
       (bytes).should.be.ok;
       (bytes).should.be.type("object");
-      (bytes.length).should.be.equal(202);
-    });
+      (bytes.length).should.be.equal(202)
+    })
 
     it("should return Buffer of transaction with second signature and buffer must be 266 length", function () {
       var transaction = {
@@ -74,24 +74,24 @@ describe("crypto.js", function () {
         signature: "618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a",
         signSignature: "618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a",
         id: "13987348420913138422"
-      };
+      }
 
       bytes = getBytes(transaction);
       (bytes).should.be.ok;
       (bytes).should.be.type("object");
-      (bytes.length).should.be.equal(266);
-    });
-  });
+      (bytes.length).should.be.equal(266)
+    })
+  })
 
   describe("#getHash", function () {
-    var getHash = crypto.getHash;
+    var getHash = crypto.getHash
 
     it("should be ok", function () {
-      (getHash).should.be.ok;
-    });
+      (getHash).should.be.ok
+    })
 
     it("should be a function", function () {
-      (getHash).should.be.type("function");
+      (getHash).should.be.type("function")
     })
 
     it("should return Buffer and Buffer most be 32 bytes length", function () {
@@ -104,25 +104,25 @@ describe("crypto.js", function () {
         asset: {},
         senderPublicKey: "5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09",
         signature: "618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a",
-      };
+      }
 
       var result = getHash(transaction);
       (result).should.be.ok;
       (result).should.be.type("object");
-      (result.length).should.be.equal(32);
-    });
-  });
+      (result.length).should.be.equal(32)
+    })
+  })
 
   describe("#getId", function () {
-    var getId = crypto.getId;
+    var getId = crypto.getId
 
     it("should be ok", function () {
-      (getId).should.be.ok;
-    });
+      (getId).should.be.ok
+    })
 
     it("should be a function", function () {
-      (getId).should.be.type("function");
-    });
+      (getId).should.be.type("function")
+    })
 
     it("should return string id and be equal to 619fd7971db6f317fdee3675c862291c976d072a0a1782410e3a6f5309022491", function () {
       var transaction = {
@@ -134,101 +134,101 @@ describe("crypto.js", function () {
         asset: {},
         senderPublicKey: "5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09",
         signature: "618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a"
-      };
+      }
 
       var id = getId(transaction);
-      (id).should.be.type("string").and.equal("952e33b66c35a3805015657c008e73a0dee1efefd9af8c41adb59fe79745ccea");
-    });
-  });
+      (id).should.be.type("string").and.equal("952e33b66c35a3805015657c008e73a0dee1efefd9af8c41adb59fe79745ccea")
+    })
+  })
 
   describe("#getFee", function () {
-    var getFee = crypto.getFee;
+    var getFee = crypto.getFee
 
     it("should be ok", function () {
-      (getFee).should.be.ok;
+      (getFee).should.be.ok
     })
 
     it("should be a function", function () {
-      (getFee).should.be.type("function");
-    });
+      (getFee).should.be.type("function")
+    })
 
     it("should return number", function () {
       var fee = getFee({amount: 100000, type: 0});
       (fee).should.be.type("number");
-      (fee).should.be.not.NaN;
-    });
+      (fee).should.be.not.NaN
+    })
 
     it("should return 10000000", function () {
       var fee = getFee({amount: 100000, type: 0});
-      (fee).should.be.type("number").and.equal(10000000);
-    });
+      (fee).should.be.type("number").and.equal(10000000)
+    })
 
     it("should return 10000000000", function () {
       var fee = getFee({type: 1});
-      (fee).should.be.type("number").and.equal(10000000000);
-    });
+      (fee).should.be.type("number").and.equal(10000000000)
+    })
 
     it("should be equal 1000000000000", function () {
       var fee = getFee({type: 2});
-      (fee).should.be.type("number").and.equal(1000000000000);
-    });
+      (fee).should.be.type("number").and.equal(1000000000000)
+    })
 
     it("should be equal 100000000", function () {
       var fee = getFee({type: 3});
-      (fee).should.be.type("number").and.equal(100000000);
-    });
-  });
+      (fee).should.be.type("number").and.equal(100000000)
+    })
+  })
 
   describe("fixedPoint", function () {
-    var fixedPoint = crypto.fixedPoint;
+    var fixedPoint = crypto.fixedPoint
 
     it("should be ok", function () {
-      (fixedPoint).should.be.ok;
+      (fixedPoint).should.be.ok
     })
 
     it("should be number", function () {
-      (fixedPoint).should.be.type("number").and.not.NaN;
-    });
+      (fixedPoint).should.be.type("number").and.not.NaN
+    })
 
     it("should be equal 100000000", function () {
-      (fixedPoint).should.be.equal(100000000);
-    });
-  });
+      (fixedPoint).should.be.equal(100000000)
+    })
+  })
 
   describe("#sign", function () {
-    var sign = crypto.sign;
+    var sign = crypto.sign
 
     it("should be ok", function () {
-      (sign).should.be.ok;
-    });
+      (sign).should.be.ok
+    })
 
     it("should be a function", function () {
-      (sign).should.be.type("function");
-    });
-  });
+      (sign).should.be.type("function")
+    })
+  })
 
   describe("#secondSign", function () {
-    var secondSign = crypto.secondSign;
+    var secondSign = crypto.secondSign
 
     it("should be ok", function () {
-      (secondSign).should.be.ok;
-    });
+      (secondSign).should.be.ok
+    })
 
     it("should be a function", function () {
-      (secondSign).should.be.type("function");
-    });
-  });
+      (secondSign).should.be.type("function")
+    })
+  })
 
   describe("#getKeys", function () {
-    var getKeys = crypto.getKeys;
+    var getKeys = crypto.getKeys
 
     it("should be ok", function () {
-      (getKeys).should.be.ok;
-    });
+      (getKeys).should.be.ok
+    })
 
     it("should be a function", function () {
-      (getKeys).should.be.type("function");
-    });
+      (getKeys).should.be.type("function")
+    })
 
     it("should return two keys in hex", function () {
       var keys = getKeys("secret");
@@ -239,256 +239,256 @@ describe("crypto.js", function () {
       (keys).should.have.property("privateKey");
       (keys.publicKey).should.be.type("string").and.match(function () {
         try {
-          new Buffer(keys.publicKey, "hex");
+          new Buffer(keys.publicKey, "hex")
         } catch (e) {
-          return false;
+          return false
         }
 
-        return true;
+        return true
       });
       (keys.privateKey).should.be.type("string").and.match(function () {
         try {
-          new Buffer(keys.privateKey, "hex");
+          new Buffer(keys.privateKey, "hex")
         } catch (e) {
-          return false;
+          return false
         }
 
-        return true;
-      });
-    });
-  });
+        return true
+      })
+    })
+  })
 
   describe("#getAddress", function () {
-    var getAddress = crypto.getAddress;
+    var getAddress = crypto.getAddress
 
     it("should be ok", function () {
-      (getAddress).should.be.ok;
+      (getAddress).should.be.ok
     })
 
     it("should be a function", function () {
-      (getAddress).should.be.type("function");
-    });
+      (getAddress).should.be.type("function")
+    })
 
     it("should generate address by publicKey", function () {
-      var keys = crypto.getKeys("secret");
+      var keys = crypto.getKeys("secret")
       var address = getAddress(keys.publicKey);
 
       (address).should.be.ok;
       (address).should.be.type("string");
-      (address).should.be.equal("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff");
-    });
+      (address).should.be.equal("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff")
+    })
 
     it("should generate address by publicKey - second test", function () {
-      var keys = crypto.getKeys("secret second test to be sure it works correctly");
+      var keys = crypto.getKeys("secret second test to be sure it works correctly")
       var address = getAddress(keys.publicKey);
 
       (address).should.be.ok;
       (address).should.be.type("string");
-      (address).should.be.equal("AQSqYnjmwj1GBL5twD4K9EBXDaTHZognox");
-    });
+      (address).should.be.equal("AQSqYnjmwj1GBL5twD4K9EBXDaTHZognox")
+    })
 
     it("should generate the same address as ECPair.getAddress()", function () {
-      var keys = crypto.getKeys("secret second test to be sure it works correctly");
-      var address = getAddress(keys.publicKey);
+      var keys = crypto.getKeys("secret second test to be sure it works correctly")
+      var address = getAddress(keys.publicKey)
 
       var Q = ecurve.Point.decodeFrom(curve, new Buffer(keys.publicKey, 'hex'))
       var keyPair = new ECPair(null, Q);
 
-      (address).should.be.equal(keyPair.getAddress());
-    });
-  });
+      (address).should.be.equal(keyPair.getAddress())
+    })
+  })
 
   describe("#verify", function () {
-    var verify = crypto.verify;
+    var verify = crypto.verify
 
     it("should be ok", function () {
-      (verify).should.be.ok;
+      (verify).should.be.ok
     })
 
     it("should be function", function () {
-      (verify).should.be.type("function");
-    });
-  });
+      (verify).should.be.type("function")
+    })
+  })
 
   describe("#verifySecondSignature", function () {
-    var verifySecondSignature = crypto.verifySecondSignature;
+    var verifySecondSignature = crypto.verifySecondSignature
 
     it("should be ok", function () {
-      (verifySecondSignature).should.be.ok;
-    });
+      (verifySecondSignature).should.be.ok
+    })
 
     it("should be function", function () {
-      (verifySecondSignature).should.be.type("function");
-    });
-  });
-});
+      (verifySecondSignature).should.be.type("function")
+    })
+  })
+})
 
 describe("different networks", function () {
 
   it("validate address on tesnet should be ok", function () {
-    ark.crypto.setNetworkVersion(0x52);
-    ark.crypto.getNetworkVersion().should.equal(0x52);
+    ark.crypto.setNetworkVersion(0x52)
+    ark.crypto.getNetworkVersion().should.equal(0x52)
     var validate = ark.crypto.validateAddress("a6fpb1BJZq4otWiVsBcuLG1ZGs5WsqqQtH");
-    (validate).should.equal(true);
-    ark.crypto.setNetworkVersion(0x17);
-    ark.crypto.getNetworkVersion().should.equal(0x17);
-  });
-});
+    (validate).should.equal(true)
+    ark.crypto.setNetworkVersion(0x17)
+    ark.crypto.getNetworkVersion().should.equal(0x17)
+  })
+})
 
 describe("delegate.js", function () {
-  var delegate = ark.delegate;
+  var delegate = ark.delegate
 
   it("should be ok", function () {
-    (delegate).should.be.ok;
-  });
+    (delegate).should.be.ok
+  })
 
   it("should be function", function () {
-    (delegate).should.be.type("object");
-  });
+    (delegate).should.be.type("object")
+  })
 
   it("should have property createDelegate", function () {
-    (delegate).should.have.property("createDelegate");
-  });
+    (delegate).should.have.property("createDelegate")
+  })
 
   describe("#createDelegate", function () {
-    var createDelegate = delegate.createDelegate;
-    var trs = null;
+    var createDelegate = delegate.createDelegate
+    var trs = null
 
     it("should be ok", function () {
-      (createDelegate).should.be.ok;
-    });
+      (createDelegate).should.be.ok
+    })
 
     it("should be function", function () {
-      (createDelegate).should.be.type("function");
-    });
+      (createDelegate).should.be.type("function")
+    })
 
     it("should create delegate", function () {
-      trs = createDelegate("secret", "delegate", "secret 2");
-    });
+      trs = createDelegate("secret", "delegate", "secret 2")
+    })
 
     it("should be deserialised correctly", function () {
-      var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
-      delete deserialisedTx.vendorFieldHex;
+      var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"))
+      delete deserialisedTx.vendorFieldHex
       var keys = Object.keys(deserialisedTx)
       for(var key in keys){
         if(keys[key] == "asset"){
-          deserialisedTx.asset.delegate.username.should.equal(trs.asset.delegate.username);
+          deserialisedTx.asset.delegate.username.should.equal(trs.asset.delegate.username)
         }
         else {
-          deserialisedTx[keys[key]].should.equal(trs[keys[key]]);
+          deserialisedTx[keys[key]].should.equal(trs[keys[key]])
         }
       }
-    });
+    })
 
     describe("returned delegate", function () {
-      var keys = ark.crypto.getKeys("secret");
-      var secondKeys = ark.crypto.getKeys("secret 2");
+      var keys = ark.crypto.getKeys("secret")
+      var secondKeys = ark.crypto.getKeys("secret 2")
 
       it("should be ok", function () {
-        (trs).should.be.ok;
-      });
+        (trs).should.be.ok
+      })
 
       it("should be object", function () {
-        (trs).should.be.type("object");
-      });
+        (trs).should.be.type("object")
+      })
 
       it("should have recipientId equal null", function () {
-        (trs).should.have.property("recipientId").and.type("object").and.be.empty;
+        (trs).should.have.property("recipientId").and.type("object").and.be.empty
       })
 
       it("shoud have amount equal 0", function () {
-        (trs).should.have.property("amount").and.type("number").and.equal(0);
+        (trs).should.have.property("amount").and.type("number").and.equal(0)
       })
 
       it("should have type equal 2", function () {
-        (trs).should.have.property("type").and.type("number").and.equal(2);
-      });
+        (trs).should.have.property("type").and.type("number").and.equal(2)
+      })
 
       // it("should have id equal 11636400490162225218", function () {
       // 	(trs).should.have.property("id").and.type("string").and.equal('11636400490162225218');
       // });
 
       it("should have timestamp number", function () {
-        (trs).should.have.property("timestamp").and.type("number");
-      });
+        (trs).should.have.property("timestamp").and.type("number")
+      })
 
       it("should have senderPublicKey in hex", function () {
         (trs).should.have.property("senderPublicKey").and.type("string").and.match(function () {
           try {
-            new Buffer(trs.senderPublicKey, "hex");
+            new Buffer(trs.senderPublicKey, "hex")
           } catch (e) {
-            return false;
+            return false
           }
 
-          return true;
-        }).and.equal(keys.publicKey);
-      });
+          return true
+        }).and.equal(keys.publicKey)
+      })
 
       it("should have signature in hex", function () {
         (trs).should.have.property("signature").and.type("string").and.match(function () {
           try {
-            new Buffer(trs.signature, "hex");
+            new Buffer(trs.signature, "hex")
           } catch (e) {
-            return false;
+            return false
           }
 
-          return true;
-        });
-      });
+          return true
+        })
+      })
 
       it("should have second signature in hex", function () {
         (trs).should.have.property("signSignature").and.type("string").and.match(function () {
           try {
-            new Buffer(trs.signSignature, "hex");
+            new Buffer(trs.signSignature, "hex")
           } catch (e) {
-            return false;
+            return false
           }
 
-          return true;
-        });
-      });
+          return true
+        })
+      })
 
       it("should have delegate asset", function () {
         (trs).should.have.property("asset").and.type("object");
-        (trs.asset).should.have.have.property("delegate");
+        (trs.asset).should.have.have.property("delegate")
       })
 
       it("should be signed correctly", function () {
         var result = ark.crypto.verify(trs);
-        (result).should.be.ok;
-      });
+        (result).should.be.ok
+      })
 
       it("should be second signed correctly", function () {
         var result = ark.crypto.verifySecondSignature(trs, secondKeys.publicKey);
-        (result).should.be.ok;
-      });
+        (result).should.be.ok
+      })
 
       it("should not be signed correctly now", function () {
-        trs.amount = 100;
+        trs.amount = 100
         var result = ark.crypto.verify(trs);
-        (result).should.be.not.ok;
-      });
+        (result).should.be.not.ok
+      })
 
       it("should not be second signed correctly now", function () {
-        trs.amount = 100;
+        trs.amount = 100
         var result = ark.crypto.verifySecondSignature(trs, secondKeys.publicKey);
-        (result).should.be.not.ok;
-      });
+        (result).should.be.not.ok
+      })
 
       describe("delegate asset", function () {
         it("should be ok", function () {
-          (trs.asset.delegate).should.be.ok;
-        });
+          (trs.asset.delegate).should.be.ok
+        })
 
         it("should be object", function () {
-          (trs.asset.delegate).should.be.type("object");
-        });
+          (trs.asset.delegate).should.be.type("object")
+        })
 
         it("should be have property username", function () {
-          (trs.asset.delegate).should.have.property("username").and.be.type("string").and.equal("delegate");
-        });
-      });
-    });
-  });
+          (trs.asset.delegate).should.have.property("username").and.be.type("string").and.equal("delegate")
+        })
+      })
+    })
+  })
 
-});
+})

--- a/test/crypto/index.js
+++ b/test/crypto/index.js
@@ -1,5 +1,7 @@
+/* eslint-disable max-len */
+
+require("should");
 var Buffer = require("buffer/").Buffer;
-var should = require("should");
 var ark = require("../../index.js");
 var ECPair = require('../../lib/ecpair');
 
@@ -20,7 +22,10 @@ describe("crypto.js", function () {
   });
 
   it("should has properties", function () {
-    var properties = ["getBytes", "getHash", "getId", "getFee", "sign", "secondSign", "getKeys", "getAddress", "verify", "verifySecondSignature", "fixedPoint"];
+    var properties = [
+      "getBytes", "getHash", "getId", "getFee", "sign", "secondSign",
+      "getKeys", "getAddress", "verify", "verifySecondSignature", "fixedPoint"
+    ];
     properties.forEach(function (property) {
       (crypto).should.have.property(property);
     });
@@ -365,7 +370,7 @@ describe("delegate.js", function () {
       var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
       delete deserialisedTx.vendorFieldHex;
       var keys = Object.keys(deserialisedTx)
-      for(key in keys){
+      for(var key in keys){
         if(keys[key] == "asset"){
           deserialisedTx.asset.delegate.username.should.equal(trs.asset.delegate.username);
         }

--- a/test/ecdsa/index.js
+++ b/test/ecdsa/index.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 var assert = require('assert')
 var bcrypto = require('../../lib/crypto')
 var ecdsa = require('../../lib/ecdsa')

--- a/test/ecpair/index.js
+++ b/test/ecpair/index.js
@@ -230,19 +230,19 @@ describe('ECPair', function () {
       })
     })
 
-    describe('verify', function () {
-      // var signature
-      //
-      // beforeEach(function () {
-      //   signature = keyPair.sign(hash)
-      // })
-      //
-      // it('wraps ecdsa.verify', sinon.test(function () {
-      //   this.mock(ecdsa).expects('verify')
-      //     .once().withArgs(hash, signature, keyPair.Q)
-      //
-      //   keyPair.verify(hash, signature)
-      // }))
-    })
+    // describe('verify', function () {
+    //   var signature
+    //
+    //   beforeEach(function () {
+    //     signature = keyPair.sign(hash)
+    //   })
+    //
+    //   it('wraps ecdsa.verify', sinon.test(function () {
+    //     this.mock(ecdsa).expects('verify')
+    //       .once().withArgs(hash, signature, keyPair.Q)
+    //
+    //     keyPair.verify(hash, signature)
+    //   }))
+    // })
   })
 })

--- a/test/ecpair/index.js
+++ b/test/ecpair/index.js
@@ -1,6 +1,3 @@
-/* global describe, it, beforeEach */
-/* eslint-disable no-new */
-
 var assert = require('assert')
 var ecdsa = require('../../lib/ecdsa')
 var ecurve = require('ecurve')
@@ -234,12 +231,12 @@ describe('ECPair', function () {
     })
 
     describe('verify', function () {
-      var signature
-
-      beforeEach(function () {
-        signature = keyPair.sign(hash)
-      })
-
+      // var signature
+      //
+      // beforeEach(function () {
+      //   signature = keyPair.sign(hash)
+      // })
+      //
       // it('wraps ecdsa.verify', sinon.test(function () {
       //   this.mock(ecdsa).expects('verify')
       //     .once().withArgs(hash, signature, keyPair.Q)

--- a/test/ecsignature/index.js
+++ b/test/ecsignature/index.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 var assert = require('assert')
 
 var BigInteger = require('bigi')

--- a/test/hdnode/index.js
+++ b/test/hdnode/index.js
@@ -1,5 +1,4 @@
-/* global describe, it, beforeEach */
-/* eslint-disable no-new */
+/* eslint-disable max-len */
 
 var assert = require('assert')
 var ecdsa = require('../../lib/ecdsa')
@@ -298,7 +297,7 @@ describe('HDNode', function () {
       })
 
       // FIXME: test data is only testing Private -> private for now
-      f.children.forEach(function (c, i) {
+      f.children.forEach(function (c) {
         if (c.m === undefined) return
 
         it(c.path + ' from ' + f.master.fingerprint, function () {

--- a/test/integration/basic.js
+++ b/test/integration/basic.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 var assert = require('assert')
 var bigi = require('bigi')
 var ark = require('../../')

--- a/test/ipfs/index.js
+++ b/test/ipfs/index.js
@@ -1,5 +1,7 @@
+/* eslint-disable max-len */
+
+require("should");
 var Buffer = require("buffer/").Buffer;
-var should = require("should");
 var ark = require("../../index.js");
 
 describe("ipfs.js", function () {
@@ -18,20 +20,25 @@ describe("ipfs.js", function () {
     (ipfs).should.have.property("createHashRegistration");
   });
 
-  it("should create transaction with hashid", function () {
-    trs = ipfs.createHashRegistration("QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ/cat.jpg", "secret");
+  it("should create transaction with hashid & deserialise correctly", function () {
+    var trs = ipfs.createHashRegistration("QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ/cat.jpg", "secret");
     (trs).should.be.ok;
-  });
 
-  it("should be deserialised correctly", function () {
     var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
     var keys = Object.keys(deserialisedTx);
-    for(key in keys){
+    for(var key in keys){
       deserialisedTx[keys[key]].should.equal(trs[keys[key]]);
     }
   });
 
   describe("returned transaction", function () {
+    var trs
+
+    before(function () {
+      trs = ipfs.createHashRegistration("QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ/cat.jpg", "secret");
+      (trs).should.be.ok;
+    });
+
     it("should be object", function () {
       (trs).should.be.type("object");
     });

--- a/test/ipfs/index.js
+++ b/test/ipfs/index.js
@@ -1,120 +1,120 @@
 /* eslint-disable max-len */
 
-require("should");
-var Buffer = require("buffer/").Buffer;
-var ark = require("../../index.js");
+require("should")
+var Buffer = require("buffer/").Buffer
+var ark = require("../../index.js")
 
 describe("ipfs.js", function () {
 
-  var ipfs = ark.ipfs;
+  var ipfs = ark.ipfs
 
   it("should be ok", function () {
-    (ipfs).should.be.ok;
-  });
+    (ipfs).should.be.ok
+  })
 
   it("should be object", function () {
-    (ipfs).should.be.type("object");
-  });
+    (ipfs).should.be.type("object")
+  })
 
   it("should have createHashRegistration property", function () {
-    (ipfs).should.have.property("createHashRegistration");
-  });
+    (ipfs).should.have.property("createHashRegistration")
+  })
 
   it("should create transaction with hashid & deserialise correctly", function () {
     var trs = ipfs.createHashRegistration("QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ/cat.jpg", "secret");
-    (trs).should.be.ok;
+    (trs).should.be.ok
 
-    var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
-    var keys = Object.keys(deserialisedTx);
+    var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"))
+    var keys = Object.keys(deserialisedTx)
     for(var key in keys){
-      deserialisedTx[keys[key]].should.equal(trs[keys[key]]);
+      deserialisedTx[keys[key]].should.equal(trs[keys[key]])
     }
-  });
+  })
 
   describe("returned transaction", function () {
     var trs
 
     before(function () {
       trs = ipfs.createHashRegistration("QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ/cat.jpg", "secret");
-      (trs).should.be.ok;
-    });
+      (trs).should.be.ok
+    })
 
     it("should be object", function () {
-      (trs).should.be.type("object");
-    });
+      (trs).should.be.type("object")
+    })
 
     it("should have id as string", function () {
-      (trs.id).should.be.type("string");
-    });
+      (trs.id).should.be.type("string")
+    })
 
     it("should have vendorField as string", function () {
-      (trs.vendorFieldHex).should.be.type("string");
-    });
+      (trs.vendorFieldHex).should.be.type("string")
+    })
 
     it("should have vendorFieldHex equal to '00000000000000000000516d5732575169376a36633755674a546172416374703774444e696b453442327158744643664c506473676154512f6361742e6a7067'", function () {
-      (trs.vendorFieldHex).should.be.type("string").and.equal('00000000000000000000516d5732575169376a36633755674a546172416374703774444e696b453442327158744643664c506473676154512f6361742e6a7067');
-    });
+      (trs.vendorFieldHex).should.be.type("string").and.equal('00000000000000000000516d5732575169376a36633755674a546172416374703774444e696b453442327158744643664c506473676154512f6361742e6a7067')
+    })
 
     it("should have type as number and equal 5", function () {
-      (trs.type).should.be.type("number").and.equal(5);
-    });
+      (trs.type).should.be.type("number").and.equal(5)
+    })
 
     it("should have timestamp as number", function () {
-      (trs.timestamp).should.be.type("number").and.not.NaN;
-    });
+      (trs.timestamp).should.be.type("number").and.not.NaN
+    })
 
     it("should have senderPublicKey as hex string", function () {
       (trs.senderPublicKey).should.be.type("string").and.match(function () {
         try {
           new Buffer(trs.senderPublicKey, "hex")
         } catch (e) {
-          return false;
+          return false
         }
 
-        return true;
+        return true
       })
-    });
+    })
 
     it("should have amount as number and equal to 0", function () {
-      (trs.amount).should.be.type("number").and.equal(0);
-    });
+      (trs.amount).should.be.type("number").and.equal(0)
+    })
 
     it("should have empty asset object", function () {
-      (trs.asset).should.be.type("object").and.empty;
-    });
+      (trs.asset).should.be.type("object").and.empty
+    })
 
     it("should does not have second signature", function () {
-      (trs).should.not.have.property("signSignature");
-    });
+      (trs).should.not.have.property("signSignature")
+    })
 
     it("should have signature as hex string", function () {
       (trs.signature).should.be.type("string").and.match(function () {
         try {
           new Buffer(trs.signature, "hex")
         } catch (e) {
-          return false;
+          return false
         }
 
-        return true;
+        return true
       })
-    });
+    })
 
     it("should be signed correctly", function () {
       var result = ark.crypto.verify(trs);
-      (result).should.be.ok;
-    });
+      (result).should.be.ok
+    })
 
     it("should not be signed correctly now (changed amount)", function () {
-      trs.amount = 10000;
+      trs.amount = 10000
       var result = ark.crypto.verify(trs);
-      (result).should.be.not.ok;
-    });
+      (result).should.be.not.ok
+    })
 
     it("should not be signed correctly now (changed vendorField)", function () {
-      trs.vendorField = "bouloup";
+      trs.vendorField = "bouloup"
       var result = ark.crypto.verify(trs);
-      (result).should.be.not.ok;
-    });
-  });
+      (result).should.be.not.ok
+    })
+  })
 
-});
+})

--- a/test/multisignature/index.js
+++ b/test/multisignature/index.js
@@ -1,28 +1,28 @@
-var ark = require("../../index.js");
+var ark = require("../../index.js")
 
 describe("multisignature.js", function () {
 
-  var multisignature = ark.multisignature;
+  var multisignature = ark.multisignature
 
   it("should be ok", function () {
-    (multisignature).should.be.ok;
-  });
+    (multisignature).should.be.ok
+  })
 
   it("should be object", function () {
-    (multisignature).should.be.type("object");
-  });
+    (multisignature).should.be.type("object")
+  })
 
   it("should have properties", function () {
-    (multisignature).should.have.property("createMultisignature");
-  });
+    (multisignature).should.have.property("createMultisignature")
+  })
 
   describe("#createMultisignature", function () {
-    var createMultisignature = multisignature.createMultisignature;
-    var sgn = null;
+    var createMultisignature = multisignature.createMultisignature
+    var sgn = null
 
     it("should be function", function () {
-      (createMultisignature).should.be.type("function");
-    });
+      (createMultisignature).should.be.type("function")
+    })
 
     it("should create multisignature transaction", function () {
       sgn = createMultisignature(
@@ -35,15 +35,15 @@ describe("multisignature.js", function () {
         2
       );
       (sgn).should.be.ok;
-      (sgn).should.be.type("object");
-    });
+      (sgn).should.be.type("object")
+    })
 
     it("should create multisignature transaction from keys", function () {
-      var secretKey = ark.ECPair.fromSeed("secret");
-      secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex");
+      var secretKey = ark.ECPair.fromSeed("secret")
+      secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex")
 
-      var secondSecretKey = ark.ECPair.fromSeed("second secret");
-      secondSecretKey.publicKey = secondSecretKey.getPublicKeyBuffer().toString("hex");
+      var secondSecretKey = ark.ECPair.fromSeed("second secret")
+      secondSecretKey.publicKey = secondSecretKey.getPublicKeyBuffer().toString("hex")
 
       sgn = createMultisignature(secretKey, secondSecretKey,[
         "03a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933",
@@ -51,73 +51,73 @@ describe("multisignature.js", function () {
         "23a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933"],
         255, 2);
       (sgn).should.be.ok;
-      (sgn).should.be.type("object");
-    });
+      (sgn).should.be.type("object")
+    })
 
     it("should be deserialised correctly", function () {
-      var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(sgn).toString("hex"));
-      delete deserialisedTx.vendorFieldHex;
+      var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(sgn).toString("hex"))
+      delete deserialisedTx.vendorFieldHex
       var keys = Object.keys(deserialisedTx)
       for(var key in keys){
         if(keys[key] == "asset"){
-          deserialisedTx.asset.multisignature.min.should.equal(sgn.asset.multisignature.min);
-          deserialisedTx.asset.multisignature.lifetime.should.equal(sgn.asset.multisignature.lifetime);
-          deserialisedTx.asset.multisignature.keysgroup.length.should.equal(sgn.asset.multisignature.keysgroup.length);
+          deserialisedTx.asset.multisignature.min.should.equal(sgn.asset.multisignature.min)
+          deserialisedTx.asset.multisignature.lifetime.should.equal(sgn.asset.multisignature.lifetime)
+          deserialisedTx.asset.multisignature.keysgroup.length.should.equal(sgn.asset.multisignature.keysgroup.length)
           //console.log(JSON.stringify(deserialisedTx.asset.multisignature.keysgroup));
-          deserialisedTx.asset.multisignature.keysgroup[0].should.equal(sgn.asset.multisignature.keysgroup[0]);
-          deserialisedTx.asset.multisignature.keysgroup[1].should.equal(sgn.asset.multisignature.keysgroup[1]);
-          deserialisedTx.asset.multisignature.keysgroup[2].should.equal(sgn.asset.multisignature.keysgroup[2]);
+          deserialisedTx.asset.multisignature.keysgroup[0].should.equal(sgn.asset.multisignature.keysgroup[0])
+          deserialisedTx.asset.multisignature.keysgroup[1].should.equal(sgn.asset.multisignature.keysgroup[1])
+          deserialisedTx.asset.multisignature.keysgroup[2].should.equal(sgn.asset.multisignature.keysgroup[2])
         }
         else {
-          deserialisedTx[keys[key]].should.equal(sgn[keys[key]]);
+          deserialisedTx[keys[key]].should.equal(sgn[keys[key]])
         }
       }
-    });
+    })
 
     describe("returned multisignature transaction", function () {
       it("should have empty recipientId", function () {
-        (sgn).should.have.property("recipientId").equal(null);
-      });
+        (sgn).should.have.property("recipientId").equal(null)
+      })
 
       it("should have amount equal 0", function () {
-        (sgn.amount).should.be.type("number").equal(0);
-      });
+        (sgn.amount).should.be.type("number").equal(0)
+      })
 
       it("should have asset", function () {
         (sgn.asset).should.be.type("object");
-        (sgn.asset).should.be.not.empty;
-      });
+        (sgn.asset).should.be.not.empty
+      })
 
       it("should have multisignature inside asset", function () {
-        (sgn.asset).should.have.property("multisignature");
-      });
+        (sgn.asset).should.have.property("multisignature")
+      })
 
       describe("multisignature asset", function () {
         it("should be ok", function () {
-          (sgn.asset.multisignature).should.be.ok;
+          (sgn.asset.multisignature).should.be.ok
         })
 
         it("should be object", function () {
-          (sgn.asset.multisignature).should.be.type("object");
-        });
+          (sgn.asset.multisignature).should.be.type("object")
+        })
 
         it("should have min property", function () {
-          (sgn.asset.multisignature).should.have.property("min");
-        });
+          (sgn.asset.multisignature).should.have.property("min")
+        })
 
         it("should have lifetime property", function () {
-          (sgn.asset.multisignature).should.have.property("lifetime");
-        });
+          (sgn.asset.multisignature).should.have.property("lifetime")
+        })
 
         it("should have keysgroup property", function () {
-          (sgn.asset.multisignature).should.have.property("keysgroup");
-        });
+          (sgn.asset.multisignature).should.have.property("keysgroup")
+        })
 
         it("should have 3 keys keysgroup", function () {
-          (sgn.asset.multisignature.keysgroup.length).should.be.equal(3);
-        });
-      });
-    });
-  });
+          (sgn.asset.multisignature.keysgroup.length).should.be.equal(3)
+        })
+      })
+    })
+  })
 
-});
+})

--- a/test/multisignature/index.js
+++ b/test/multisignature/index.js
@@ -1,5 +1,3 @@
-var Buffer = require("buffer/").Buffer;
-var should = require("should");
 var ark = require("../../index.js");
 
 describe("multisignature.js", function () {
@@ -27,7 +25,15 @@ describe("multisignature.js", function () {
     });
 
     it("should create multisignature transaction", function () {
-      sgn = createMultisignature("secret", "second secret",["03a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933","13a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933","23a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933"], 255, 2);
+      sgn = createMultisignature(
+        "secret",
+        "second secret",
+        [ "03a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933",
+          "13a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933",
+          "23a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933"],
+        255,
+        2
+      );
       (sgn).should.be.ok;
       (sgn).should.be.type("object");
     });
@@ -36,12 +42,12 @@ describe("multisignature.js", function () {
       var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(sgn).toString("hex"));
       delete deserialisedTx.vendorFieldHex;
       var keys = Object.keys(deserialisedTx)
-      for(key in keys){
+      for(var key in keys){
         if(keys[key] == "asset"){
           deserialisedTx.asset.multisignature.min.should.equal(sgn.asset.multisignature.min);
           deserialisedTx.asset.multisignature.lifetime.should.equal(sgn.asset.multisignature.lifetime);
           deserialisedTx.asset.multisignature.keysgroup.length.should.equal(sgn.asset.multisignature.keysgroup.length);
-          console.log(JSON.stringify(deserialisedTx.asset.multisignature.keysgroup));
+          //console.log(JSON.stringify(deserialisedTx.asset.multisignature.keysgroup));
           deserialisedTx.asset.multisignature.keysgroup[0].should.equal(sgn.asset.multisignature.keysgroup[0]);
           deserialisedTx.asset.multisignature.keysgroup[1].should.equal(sgn.asset.multisignature.keysgroup[1]);
           deserialisedTx.asset.multisignature.keysgroup[2].should.equal(sgn.asset.multisignature.keysgroup[2]);

--- a/test/multisignature/index.js
+++ b/test/multisignature/index.js
@@ -45,7 +45,11 @@ describe("multisignature.js", function () {
       var secondSecretKey = ark.ECPair.fromSeed("second secret");
       secondSecretKey.publicKey = secondSecretKey.getPublicKeyBuffer().toString("hex");
 
-      sgn = createMultisignature(secretKey, secondSecretKey,["03a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933","13a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933","23a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933"], 255, 2);
+      sgn = createMultisignature(secretKey, secondSecretKey,[
+        "03a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933",
+        "13a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933",
+        "23a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933"],
+        255, 2);
       (sgn).should.be.ok;
       (sgn).should.be.type("object");
     });

--- a/test/signature/index.js
+++ b/test/signature/index.js
@@ -1,5 +1,5 @@
+require("should");
 var Buffer = require("buffer/").Buffer;
-var should = require("should");
 var ark = require("../../index.js");
 
 describe("signature.js", function () {
@@ -36,7 +36,7 @@ describe("signature.js", function () {
       var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(sgn).toString("hex"));
       delete deserialisedTx.vendorFieldHex;
       var keys = Object.keys(deserialisedTx)
-      for(key in keys){
+      for(var key in keys){
         if(keys[key] == "asset"){
           deserialisedTx.asset.signature.publicKey.should.equal(sgn.asset.signature.publicKey);
         }

--- a/test/signature/index.js
+++ b/test/signature/index.js
@@ -1,109 +1,109 @@
-require("should");
-var Buffer = require("buffer/").Buffer;
-var ark = require("../../index.js");
+require("should")
+var Buffer = require("buffer/").Buffer
+var ark = require("../../index.js")
 
 describe("signature.js", function () {
 
-  var signature = ark.signature;
+  var signature = ark.signature
 
   it("should be ok", function () {
-    (signature).should.be.ok;
-  });
+    (signature).should.be.ok
+  })
 
   it("should be object", function () {
-    (signature).should.be.type("object");
-  });
+    (signature).should.be.type("object")
+  })
 
   it("should have properties", function () {
-    (signature).should.have.property("createSignature");
-  });
+    (signature).should.have.property("createSignature")
+  })
 
   describe("#createSignature", function () {
-    var createSignature = signature.createSignature;
-    var sgn = null;
+    var createSignature = signature.createSignature
+    var sgn = null
 
     it("should be function", function () {
-      (createSignature).should.be.type("function");
-    });
+      (createSignature).should.be.type("function")
+    })
 
     it("should create signature transaction", function () {
       sgn = createSignature("secret", "second secret");
       (sgn).should.be.ok;
-      (sgn).should.be.type("object");
-    });
+      (sgn).should.be.type("object")
+    })
 
     it("should create signature transaction", function () {
-      var secretKey = ark.ECPair.fromSeed("secret");
-      secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex");
+      var secretKey = ark.ECPair.fromSeed("secret")
+      secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex")
 
       sgn = createSignature(secretKey, "second secret");
       (sgn).should.be.ok;
-      (sgn).should.be.type("object");
-    });
+      (sgn).should.be.type("object")
+    })
 
     it("should be deserialised correctly", function () {
-      var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(sgn).toString("hex"));
-      delete deserialisedTx.vendorFieldHex;
+      var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(sgn).toString("hex"))
+      delete deserialisedTx.vendorFieldHex
       var keys = Object.keys(deserialisedTx)
       for(var key in keys){
         if(keys[key] == "asset"){
-          deserialisedTx.asset.signature.publicKey.should.equal(sgn.asset.signature.publicKey);
+          deserialisedTx.asset.signature.publicKey.should.equal(sgn.asset.signature.publicKey)
         }
         else {
-          deserialisedTx[keys[key]].should.equal(sgn[keys[key]]);
+          deserialisedTx[keys[key]].should.equal(sgn[keys[key]])
         }
       }
-    });
+    })
 
     describe("returned signature transaction", function () {
       it("should have empty recipientId", function () {
-        (sgn).should.have.property("recipientId").equal(null);
-      });
+        (sgn).should.have.property("recipientId").equal(null)
+      })
 
       it("should have amount equal 0", function () {
-        (sgn.amount).should.be.type("number").equal(0);
-      });
+        (sgn.amount).should.be.type("number").equal(0)
+      })
 
       it("should have asset", function () {
         (sgn.asset).should.be.type("object");
-        (sgn.asset).should.be.not.empty;
-      });
+        (sgn.asset).should.be.not.empty
+      })
 
       it("should have signature inside asset", function () {
-        (sgn.asset).should.have.property("signature");
-      });
+        (sgn.asset).should.have.property("signature")
+      })
 
       describe("signature asset", function () {
         it("should be ok", function () {
-          (sgn.asset.signature).should.be.ok;
+          (sgn.asset.signature).should.be.ok
         })
 
         it("should be object", function () {
-          (sgn.asset.signature).should.be.type("object");
-        });
+          (sgn.asset.signature).should.be.type("object")
+        })
 
         it("should have publicKey property", function () {
-          (sgn.asset.signature).should.have.property("publicKey");
-        });
+          (sgn.asset.signature).should.have.property("publicKey")
+        })
 
         it("should have publicKey in hex", function () {
           (sgn.asset.signature.publicKey).should.be.type("string").and.match(function () {
             try {
-              new Buffer(sgn.asset.signature.publicKey);
+              new Buffer(sgn.asset.signature.publicKey)
             } catch (e) {
-              return false;
+              return false
             }
 
-            return true;
-          });
-        });
+            return true
+          })
+        })
 
         it("should have publicKey in 33 bytes", function () {
           var publicKey = new Buffer(sgn.asset.signature.publicKey, "hex");
-          (publicKey.length).should.be.equal(33);
-        });
-      });
-    });
-  });
+          (publicKey.length).should.be.equal(33)
+        })
+      })
+    })
+  })
 
-});
+})

--- a/test/slot/index.js
+++ b/test/slot/index.js
@@ -1,154 +1,154 @@
-require("should");
+require("should")
 
 describe("slots.js", function () {
 
-  var slots = require("../../lib/time/slots.js");
+  var slots = require("../../lib/time/slots.js")
 
   it("should be ok", function () {
-    (slots).should.be.ok;
-  });
+    (slots).should.be.ok
+  })
 
   it("should be object", function () {
-    (slots).should.be.type("object");
-  });
+    (slots).should.be.type("object")
+  })
 
   it("should have properties", function () {
-    var properties = ["interval", "delegates", "getTime", "getRealTime", "getSlotNumber", "getSlotTime", "getNextSlot", "getLastSlot"];
+    var properties = ["interval", "delegates", "getTime", "getRealTime", "getSlotNumber", "getSlotTime", "getNextSlot", "getLastSlot"]
     properties.forEach(function (property) {
-      (slots).should.have.property(property);
-    });
-  });
+      (slots).should.have.property(property)
+    })
+  })
 
   describe(".interval", function () {
-    var interval = slots.interval;
+    var interval = slots.interval
 
     it("should be ok", function () {
-      (interval).should.be.ok;
-    });
+      (interval).should.be.ok
+    })
 
     it("should be number and not NaN", function () {
-      (interval).should.be.type("number").and.not.NaN;
-    });
-  });
+      (interval).should.be.type("number").and.not.NaN
+    })
+  })
 
   describe(".delegates", function () {
-    var delegates = slots.delegates;
+    var delegates = slots.delegates
 
     it("should be ok", function () {
-      (delegates).should.be.ok;
-    });
+      (delegates).should.be.ok
+    })
 
     it("should be number and not NaN", function () {
-      (delegates).should.be.type("number").and.not.NaN;
-    });
-  });
+      (delegates).should.be.type("number").and.not.NaN
+    })
+  })
 
   describe("#getTime", function () {
-    var getTime = slots.getTime;
+    var getTime = slots.getTime
 
     it("should be ok", function () {
-      (getTime).should.be.ok;
-    });
+      (getTime).should.be.ok
+    })
 
     it("should be a function", function () {
-      (getTime).should.be.type("function");
-    });
+      (getTime).should.be.type("function")
+    })
 
     it("should return epoch time as number, equal to 10", function () {
-      var d = 1490101210000;
+      var d = 1490101210000
       var time = getTime(d);
-      (time).should.be.type("number").and.equal(10);
-    });
-  });
+      (time).should.be.type("number").and.equal(10)
+    })
+  })
 
   describe("#getRealTime", function () {
-    var getRealTime = slots.getRealTime;
+    var getRealTime = slots.getRealTime
 
     it("should be ok", function () {
-      (getRealTime).should.be.ok;
-    });
+      (getRealTime).should.be.ok
+    })
 
     it("should be a function", function () {
-      (getRealTime).should.be.type("function");
-    });
+      (getRealTime).should.be.type("function")
+    })
 
     it("should return return real time, convert 10 to 1490101210000", function () {
-      var d = 10;
+      var d = 10
       var real = getRealTime(d);
       (real).should.be.ok;
-      (real).should.be.type("number").and.equal(1490101210000);
-    });
-  });
+      (real).should.be.type("number").and.equal(1490101210000)
+    })
+  })
 
   describe("#getSlotNumber", function () {
-    var getSlotNumber = slots.getSlotNumber;
+    var getSlotNumber = slots.getSlotNumber
 
     it("should be ok", function () {
-      (getSlotNumber).should.be.ok;
-    });
+      (getSlotNumber).should.be.ok
+    })
 
     it("should be a function", function () {
-      (getSlotNumber).should.be.type("function");
-    });
+      (getSlotNumber).should.be.type("function")
+    })
 
     it("should return slot number, equal to 1", function () {
       var slot = getSlotNumber(10);
-      (slot).should.be.type("number").and.equal(1);
-    });
-  });
+      (slot).should.be.type("number").and.equal(1)
+    })
+  })
 
   describe("#getSlotTime", function () {
-    var getSlotTime = slots.getSlotTime;
+    var getSlotTime = slots.getSlotTime
 
     it("should be ok", function () {
-      (getSlotTime).should.be.ok;
-    });
+      (getSlotTime).should.be.ok
+    })
 
     it("should be function", function () {
-      (getSlotTime).should.be.type("function");
-    });
+      (getSlotTime).should.be.type("function")
+    })
 
     it("should return slot time number, equal to ", function () {
       var slotTime = getSlotTime(19614);
       (slotTime).should.be.ok;
-      (slotTime).should.be.type("number").and.equal(156912);
-    });
-  });
+      (slotTime).should.be.type("number").and.equal(156912)
+    })
+  })
 
   describe("#getNextSlot", function () {
-    var getNextSlot = slots.getNextSlot;
+    var getNextSlot = slots.getNextSlot
 
     it("should be ok", function () {
-      (getNextSlot).should.be.ok;
-    });
+      (getNextSlot).should.be.ok
+    })
 
     it("should be function", function () {
-      (getNextSlot).should.be.type("function");
-    });
+      (getNextSlot).should.be.type("function")
+    })
 
     it("should return next slot number", function () {
       var nextSlot = getNextSlot();
       (nextSlot).should.be.ok;
-      (nextSlot).should.be.type("number").and.not.NaN;
-    });
-  });
+      (nextSlot).should.be.type("number").and.not.NaN
+    })
+  })
 
   describe("#getLastSlot", function () {
-    var getLastSlot = slots.getLastSlot;
+    var getLastSlot = slots.getLastSlot
 
     it("should be ok", function () {
-      (getLastSlot).should.be.ok;
-    });
+      (getLastSlot).should.be.ok
+    })
 
     it("should be function", function () {
-      (getLastSlot).should.be.type("function");
-    });
+      (getLastSlot).should.be.type("function")
+    })
 
     it("should return last slot number", function () {
       var lastSlot = getLastSlot(slots.getNextSlot());
       (lastSlot).should.be.ok;
-      (lastSlot).should.be.type("number").and.not.NaN;
-    });
-  });
+      (lastSlot).should.be.type("number").and.not.NaN
+    })
+  })
 
-});
+})

--- a/test/slot/index.js
+++ b/test/slot/index.js
@@ -1,6 +1,4 @@
-var Buffer = require("buffer/").Buffer;
-var should = require("should");
-var ark = require("../../index.js");
+require("should");
 
 describe("slots.js", function () {
 

--- a/test/transaction/index.js
+++ b/test/transaction/index.js
@@ -1,146 +1,146 @@
-var Buffer = require("buffer/").Buffer;
-var ark = require("../../index.js");
+var Buffer = require("buffer/").Buffer
+var ark = require("../../index.js")
 
 describe("transaction.js", function () {
 
-  var transaction = ark.transaction;
+  var transaction = ark.transaction
 
   it("should be object", function () {
-    (transaction).should.be.type("object");
-  });
+    (transaction).should.be.type("object")
+  })
 
   it("should have properties", function () {
-    (transaction).should.have.property("createTransaction");
+    (transaction).should.have.property("createTransaction")
   })
 
   describe("#createTransaction", function () {
-    var createTransaction = transaction.createTransaction;
-    var trs = null;
+    var createTransaction = transaction.createTransaction
+    var trs = null
 
     it("should be a function", function () {
-      (createTransaction).should.be.type("function");
-    });
+      (createTransaction).should.be.type("function")
+    })
 
     it("should create transaction without second signature", function () {
       trs = createTransaction("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff", 1000, null, "secret");
-      (trs).should.be.ok;
-    });
+      (trs).should.be.ok
+    })
 
     it("should create transaction without second signature from keys", function () {
-      var secretKey = ark.ECPair.fromSeed("secret");
-      secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex");
+      var secretKey = ark.ECPair.fromSeed("secret")
+      secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex")
 
       trs = createTransaction("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff", 1000, null, secretKey);
-      (trs).should.be.ok;
-    });
+      (trs).should.be.ok
+    })
 
     it("should create transaction with vendorField", function () {
       trs = createTransaction("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff", 1000, "this is a test vendorfield", "secret");
-      (trs).should.be.ok;
-    });
+      (trs).should.be.ok
+    })
 
     it("should fail if transaction with vendorField length > 64", function () {
-      var vf="z";
-      for(var i=0;i<6;i++){
-        vf=vf+vf;
+      var vf="z"
+      for(var i=0; i<6; i++){
+        vf=vf+vf
       }
-      vf=vf+"z";
-      trs = createTransaction("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff", 1000, vf, "secret");
-      return (trs===null).should.equal(true);
+      vf=vf+"z"
+      trs = createTransaction("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff", 1000, vf, "secret")
+      return (trs===null).should.equal(true)
 
-    });
+    })
 
     it("should be ok if transaction with vendorField length = 64", function () {
-      var vf="z";
-      for(var i=0;i<6;i++){
-        vf=vf+vf;
+      var vf="z"
+      for(var i=0; i<6; i++){
+        vf=vf+vf
       }
       trs = createTransaction("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff", 1000, vf, "secret");
-      (trs).should.be.ok;
-    });
+      (trs).should.be.ok
+    })
 
     describe("returned transaction", function () {
       it("should be object", function () {
-        (trs).should.be.type("object");
-      });
+        (trs).should.be.type("object")
+      })
 
       it("should have id as string", function () {
-        (trs.id).should.be.type("string");
-      });
+        (trs.id).should.be.type("string")
+      })
 
       it("should have type as number and eqaul 0", function () {
-        (trs.type).should.be.type("number").and.equal(0);
-      });
+        (trs.type).should.be.type("number").and.equal(0)
+      })
 
       it("should have timestamp as number", function () {
-        (trs.timestamp).should.be.type("number").and.not.NaN;
-      });
+        (trs.timestamp).should.be.type("number").and.not.NaN
+      })
 
       it("should have senderPublicKey as hex string", function () {
         (trs.senderPublicKey).should.be.type("string").and.match(function () {
           try {
             new Buffer(trs.senderPublicKey, "hex")
           } catch (e) {
-            return false;
+            return false
           }
 
-          return true;
+          return true
         })
-      });
+      })
 
       it("should have recipientId as string and to be equal AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff", function () {
-        (trs.recipientId).should.be.type("string").and.equal("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff");
-      });
+        (trs.recipientId).should.be.type("string").and.equal("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff")
+      })
 
       it("should have amount as number and eqaul to 1000", function () {
-        (trs.amount).should.be.type("number").and.equal(1000);
-      });
+        (trs.amount).should.be.type("number").and.equal(1000)
+      })
 
       it("should have empty asset object", function () {
-        (trs.asset).should.be.type("object").and.empty;
-      });
+        (trs.asset).should.be.type("object").and.empty
+      })
 
       it("should does not have second signature", function () {
-        (trs).should.not.have.property("signSignature");
-      });
+        (trs).should.not.have.property("signSignature")
+      })
 
       it("should have signature as hex string", function () {
         (trs.signature).should.be.type("string").and.match(function () {
           try {
             new Buffer(trs.signature, "hex")
           } catch (e) {
-            return false;
+            return false
           }
 
-          return true;
+          return true
         })
-      });
+      })
 
       it("should be signed correctly", function () {
-        var result = ark.crypto.verify(trs);
-        result.should.equal(true);
-      });
+        var result = ark.crypto.verify(trs)
+        result.should.equal(true)
+      })
 
       it("should be deserialised correctly", function () {
-        var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
+        var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"))
         deserialisedTx.vendorField = new Buffer(deserialisedTx.vendorFieldHex, "hex").toString("utf8")
-        delete deserialisedTx.vendorFieldHex;
+        delete deserialisedTx.vendorFieldHex
         var keys = Object.keys(deserialisedTx)
         for(var key in keys){
           if(keys[key] != "vendorFieldHex"){
-            deserialisedTx[keys[key]].should.equal(trs[keys[key]]);
+            deserialisedTx[keys[key]].should.equal(trs[keys[key]])
           }
         }
 
-      });
+      })
 
       it("should not be signed correctly now", function () {
-        trs.amount = 10000;
-        var result = ark.crypto.verify(trs);
-        result.should.equal(false);
-      });
-    });
-  });
+        trs.amount = 10000
+        var result = ark.crypto.verify(trs)
+        result.should.equal(false)
+      })
+    })
+  })
 
   describe("createTransaction and try to tamper signature", function(){
 
@@ -150,31 +150,31 @@ describe("transaction.js", function () {
 
       // custom bip66 encode for hacking away signature
       function BIP66_encode (r, s) {
-        var lenR = r.length;
-        var lenS = s.length;
-        var signature = new Buffer(6 + lenR + lenS);
+        var lenR = r.length
+        var lenS = s.length
+        var signature = new Buffer(6 + lenR + lenS)
 
         // 0x30 [total-length] 0x02 [R-length] [R] 0x02 [S-length] [S]
-        signature[0] = 0x30;
-        signature[1] = signature.length - 2;
-        signature[2] = 0x02;
-        signature[3] = r.length;
-        r.copy(signature, 4);
-        signature[4 + lenR] = 0x02;
-        signature[5 + lenR] = s.length;
-        s.copy(signature, 6 + lenR);
+        signature[0] = 0x30
+        signature[1] = signature.length - 2
+        signature[2] = 0x02
+        signature[3] = r.length
+        r.copy(signature, 4)
+        signature[4 + lenR] = 0x02
+        signature[5 + lenR] = s.length
+        s.copy(signature, 6 + lenR)
 
-        return signature;
+        return signature
       }
 
       // The transaction to replay
-      var old_transaction = ark.transaction.createTransaction('AacRfTLtxAkR3Mind1XdPCddj1uDkHtwzD', 1, null, 'randomstring');
+      var old_transaction = ark.transaction.createTransaction('AacRfTLtxAkR3Mind1XdPCddj1uDkHtwzD', 1, null, 'randomstring')
 
       // Decode signature
-      var decode = bip66.decode(Buffer(old_transaction.signature, "hex"));
+      var decode = bip66.decode(Buffer(old_transaction.signature, "hex"))
 
-      var r = BigInteger.fromDERInteger(decode.r);
-      var s = BigInteger.fromDERInteger(decode.s);
+      var r = BigInteger.fromDERInteger(decode.r)
+      var s = BigInteger.fromDERInteger(decode.s)
 
       // Transform the signature
       /*
@@ -183,157 +183,157 @@ describe("transaction.js", function () {
       r = r + result
       */
 
-      var result = BigInteger.fromBuffer(Buffer(r.toBuffer(r.toDERInteger().length).toString('hex') + '06', 'hex'));
-      result = result.subtract(r);
-      r = r.add(result);
+      var result = BigInteger.fromBuffer(Buffer(r.toBuffer(r.toDERInteger().length).toString('hex') + '06', 'hex'))
+      result = result.subtract(r)
+      r = r.add(result)
 
-      var new_signature = BIP66_encode(r.toBuffer(r.toDERInteger().length), s.toBuffer(s.toDERInteger().length)).toString('hex');
+      var new_signature = BIP66_encode(r.toBuffer(r.toDERInteger().length), s.toBuffer(s.toDERInteger().length)).toString('hex')
       //
       // console.log("OLD TRANSACTION : ");
       // console.log("TXID " + ark.crypto.getId(old_transaction));
       // console.log("VERIFY " + ark.crypto.verify(old_transaction));
       // console.log("SIG " + old_transaction.signature + "\n");
 
-      ark.crypto.verify(old_transaction).should.equal(true);
+      ark.crypto.verify(old_transaction).should.equal(true)
 
-      old_transaction.signature = new_signature;
+      old_transaction.signature = new_signature
       //
       // console.log("NEW TRANSACTION : ");
       // console.log("TXID " + ark.crypto.getId(old_transaction));
       // console.log("VERIFY " + ark.crypto.verify(old_transaction));
       // console.log("SIG " + old_transaction.signature);
 
-      ark.crypto.verify(old_transaction).should.equal(false);
+      ark.crypto.verify(old_transaction).should.equal(false)
 
-    });
+    })
 
-  });
+  })
 
   describe("#createTransaction with second secret", function () {
-    var createTransaction = transaction.createTransaction;
-    var trs = null;
-    var secondSecret = "second secret";
-    var keys = ark.crypto.getKeys(secondSecret);
+    var createTransaction = transaction.createTransaction
+    var trs = null
+    var secondSecret = "second secret"
+    var keys = ark.crypto.getKeys(secondSecret)
 
     it("should be a function", function () {
-      (createTransaction).should.be.type("function");
-    });
+      (createTransaction).should.be.type("function")
+    })
 
     it("should not accept bitcoin address", function(){
       try {
-        trs = createTransaction("14owCmVDn8SaAFZcLbZfCVu5jvc4Lq7Tm1", 1000, null, "secret", secondSecret);
+        trs = createTransaction("14owCmVDn8SaAFZcLbZfCVu5jvc4Lq7Tm1", 1000, null, "secret", secondSecret)
       } catch(error){
         return (error).should.have.property("message").and.equal("Wrong recipientId")
       }
-      true.should.equal(false);
-    });
+      true.should.equal(false)
+    })
 
     it("should create transaction without second signature", function () {
       trs = createTransaction("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff", 1000, null, "secret", secondSecret);
-      (trs).should.be.ok;
-    });
+      (trs).should.be.ok
+    })
 
     describe("returned transaction", function () {
       it("should be object", function () {
-        (trs).should.be.type("object");
-      });
+        (trs).should.be.type("object")
+      })
 
       it("should have id as string", function () {
-        (trs.id).should.be.type("string");
-      });
+        (trs.id).should.be.type("string")
+      })
 
       it("should have type as number and eqaul 0", function () {
-        (trs.type).should.be.type("number").and.equal(0);
-      });
+        (trs.type).should.be.type("number").and.equal(0)
+      })
 
       it("should have timestamp as number", function () {
-        (trs.timestamp).should.be.type("number").and.not.NaN;
-      });
+        (trs.timestamp).should.be.type("number").and.not.NaN
+      })
 
       it("should have senderPublicKey as hex string", function () {
         (trs.senderPublicKey).should.be.type("string").and.match(function () {
           try {
             new Buffer(trs.senderPublicKey, "hex")
           } catch (e) {
-            return false;
+            return false
           }
 
-          return true;
+          return true
         })
-      });
+      })
 
       it("should have recipientId as string and to be equal AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff", function () {
-        (trs.recipientId).should.be.type("string").and.equal("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff");
-      });
+        (trs.recipientId).should.be.type("string").and.equal("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff")
+      })
 
       it("should have amount as number and eqaul to 1000", function () {
-        (trs.amount).should.be.type("number").and.equal(1000);
-      });
+        (trs.amount).should.be.type("number").and.equal(1000)
+      })
 
       it("should have empty asset object", function () {
-        (trs.asset).should.be.type("object").and.empty;
-      });
+        (trs.asset).should.be.type("object").and.empty
+      })
 
       it("should have second signature", function () {
-        (trs).should.have.property("signSignature");
-      });
+        (trs).should.have.property("signSignature")
+      })
 
       it("should have signature as hex string", function () {
         (trs.signature).should.be.type("string").and.match(function () {
           try {
             new Buffer(trs.signature, "hex")
           } catch (e) {
-            return false;
+            return false
           }
 
-          return true;
+          return true
         })
-      });
+      })
 
       it("should have signSignature as hex string", function () {
         (trs.signSignature).should.be.type("string").and.match(function () {
           try {
-            new Buffer(trs.signSignature, "hex");
+            new Buffer(trs.signSignature, "hex")
           } catch (e) {
-            return false;
+            return false
           }
 
-          return true;
-        });
-      });
+          return true
+        })
+      })
 
       it("should be deserialised correctly", function () {
-        var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
-        delete deserialisedTx.vendorFieldHex;
+        var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"))
+        delete deserialisedTx.vendorFieldHex
         var keys = Object.keys(deserialisedTx)
         for(var key in keys){
-          deserialisedTx[keys[key]].should.equal(trs[keys[key]]);
+          deserialisedTx[keys[key]].should.equal(trs[keys[key]])
         }
 
-      });
+      })
 
       it("should be signed correctly", function () {
         var result = ark.crypto.verify(trs);
-        (result).should.equal(true);
-      });
+        (result).should.equal(true)
+      })
 
       it("should be second signed correctly", function () {
         var result = ark.crypto.verifySecondSignature(trs, keys.publicKey);
-        (result).should.equal(true);
-      });
+        (result).should.equal(true)
+      })
 
       it("should not be signed correctly now", function () {
-        trs.amount = 10000;
+        trs.amount = 10000
         var result = ark.crypto.verify(trs);
-        (result).should.equal(false);
-      });
+        (result).should.equal(false)
+      })
 
       it("should not be second signed correctly now", function () {
-        trs.amount = 10000;
+        trs.amount = 10000
         var result = ark.crypto.verifySecondSignature(trs, keys.publicKey);
-        (result).should.equal(false);
-      });
-    });
-  });
+        (result).should.equal(false)
+      })
+    })
+  })
 
-});
+})

--- a/test/transaction/index.js
+++ b/test/transaction/index.js
@@ -1,5 +1,4 @@
 var Buffer = require("buffer/").Buffer;
-var should = require("should");
 var ark = require("../../index.js");
 
 describe("transaction.js", function () {
@@ -34,7 +33,7 @@ describe("transaction.js", function () {
 
     it("should fail if transaction with vendorField length > 64", function () {
       var vf="z";
-      for(i=0;i<6;i++){
+      for(var i=0;i<6;i++){
         vf=vf+vf;
       }
       vf=vf+"z";
@@ -45,7 +44,7 @@ describe("transaction.js", function () {
 
     it("should be ok if transaction with vendorField length = 64", function () {
       var vf="z";
-      for(i=0;i<6;i++){
+      for(var i=0;i<6;i++){
         vf=vf+vf;
       }
       trs = createTransaction("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff", 1000, vf, "secret");
@@ -119,7 +118,7 @@ describe("transaction.js", function () {
         deserialisedTx.vendorField = new Buffer(deserialisedTx.vendorFieldHex, "hex").toString("utf8")
         delete deserialisedTx.vendorFieldHex;
         var keys = Object.keys(deserialisedTx)
-        for(key in keys){
+        for(var key in keys){
           if(keys[key] != "vendorFieldHex"){
             deserialisedTx[keys[key]].should.equal(trs[keys[key]]);
           }
@@ -176,11 +175,11 @@ describe("transaction.js", function () {
       r = r + result
       */
 
-      result = BigInteger.fromBuffer(Buffer(r.toBuffer(r.toDERInteger().length).toString('hex') + '06', 'hex'));
+      var result = BigInteger.fromBuffer(Buffer(r.toBuffer(r.toDERInteger().length).toString('hex') + '06', 'hex'));
       result = result.subtract(r);
       r = r.add(result);
 
-      new_signature = BIP66_encode(r.toBuffer(r.toDERInteger().length), s.toBuffer(s.toDERInteger().length)).toString('hex');
+      var new_signature = BIP66_encode(r.toBuffer(r.toDERInteger().length), s.toBuffer(s.toDERInteger().length)).toString('hex');
       //
       // console.log("OLD TRANSACTION : ");
       // console.log("TXID " + ark.crypto.getId(old_transaction));
@@ -299,7 +298,7 @@ describe("transaction.js", function () {
         var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
         delete deserialisedTx.vendorFieldHex;
         var keys = Object.keys(deserialisedTx)
-        for(key in keys){
+        for(var key in keys){
           deserialisedTx[keys[key]].should.equal(trs[keys[key]]);
         }
 

--- a/test/vote/index.js
+++ b/test/vote/index.js
@@ -1,5 +1,5 @@
+require("should");
 var Buffer = require("buffer/").Buffer;
-var should = require("should");
 var ark = require("../../index.js");
 
 describe("vote.js", function () {
@@ -40,7 +40,7 @@ describe("vote.js", function () {
       var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(vt).toString("hex"));
       delete deserialisedTx.vendorFieldHex;
       var keys = Object.keys(deserialisedTx)
-      for(key in keys){
+      for(var key in keys){
         if(keys[key] == "asset"){
           deserialisedTx.asset.votes[0].should.equal(vt.asset.votes[0]);
         }

--- a/test/vote/index.js
+++ b/test/vote/index.js
@@ -1,202 +1,202 @@
-require("should");
-var Buffer = require("buffer/").Buffer;
-var ark = require("../../index.js");
+require("should")
+var Buffer = require("buffer/").Buffer
+var ark = require("../../index.js")
 
-var NETWORKS = require('../../lib/networks');
+var NETWORKS = require('../../lib/networks')
 
 describe("vote.js", function () {
 
-  var vote = ark.vote;
+  var vote = ark.vote
 
   it("should be ok", function () {
-    (vote).should.be.ok;
-  });
+    (vote).should.be.ok
+  })
 
   it("should be object", function () {
-    (vote).should.be.type("object");
-  });
+    (vote).should.be.type("object")
+  })
 
   it("should have createVote property", function () {
-    (vote).should.have.property("createVote");
-  });
+    (vote).should.have.property("createVote")
+  })
 
   describe("#createVote", function () {
     var createVote = vote.createVote,
       vt = null,
       publicKey = ark.crypto.getKeys("secret").publicKey,
-      publicKeys = ["+" + publicKey];
+      publicKeys = ["+" + publicKey]
 
     it("should be ok", function () {
-      (createVote).should.be.ok;
-    });
+      (createVote).should.be.ok
+    })
 
     it("should be function", function () {
-      (createVote).should.be.type("function");
-    });
+      (createVote).should.be.type("function")
+    })
 
     it("should create vote", function () {
-      vt = createVote("secret", publicKeys, "second secret");
-    });
+      vt = createVote("secret", publicKeys, "second secret")
+    })
 
     it("should create vote from ecpair", function () {
-      var secretKey = ark.ECPair.fromSeed("secret");
-      secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex");
+      var secretKey = ark.ECPair.fromSeed("secret")
+      secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex")
 
-      var secondSecretKey = ark.ECPair.fromSeed("second secret");
-      secondSecretKey.publicKey = secondSecretKey.getPublicKeyBuffer().toString("hex");
+      var secondSecretKey = ark.ECPair.fromSeed("second secret")
+      secondSecretKey.publicKey = secondSecretKey.getPublicKeyBuffer().toString("hex")
 
-      vt = createVote(secretKey, publicKeys, secondSecretKey);
-    });
+      vt = createVote(secretKey, publicKeys, secondSecretKey)
+    })
 
     it("should create vote from wif", function () {
-      var secretKey = ark.ECPair.fromWIF("SB3iDxYmKgjkhfDZSKgLaBrp3Ynzd3yd3ZZF2ujVBK7vLpv6hWKK", NETWORKS.ark);
-      secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex");
+      var secretKey = ark.ECPair.fromWIF("SB3iDxYmKgjkhfDZSKgLaBrp3Ynzd3yd3ZZF2ujVBK7vLpv6hWKK", NETWORKS.ark)
+      secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex")
 
       var tx = createVote(secretKey, publicKeys);
       (tx).should.be.ok;
       (tx).should.be.type("object");
-      (tx).should.have.property("recipientId").and.be.type("string").and.be.equal("AL9uJWA5nd6RWn8VSUzGN7spWeZGHeudg9");
-    });
+      (tx).should.have.property("recipientId").and.be.type("string").and.be.equal("AL9uJWA5nd6RWn8VSUzGN7spWeZGHeudg9")
+    })
 
     it("should be deserialised correctly", function () {
-      var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(vt).toString("hex"));
-      delete deserialisedTx.vendorFieldHex;
+      var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(vt).toString("hex"))
+      delete deserialisedTx.vendorFieldHex
       var keys = Object.keys(deserialisedTx)
       for(var key in keys){
         if(keys[key] == "asset"){
-          deserialisedTx.asset.votes[0].should.equal(vt.asset.votes[0]);
+          deserialisedTx.asset.votes[0].should.equal(vt.asset.votes[0])
         }
         else{
-          deserialisedTx[keys[key]].should.equal(vt[keys[key]]);
+          deserialisedTx[keys[key]].should.equal(vt[keys[key]])
         }
       }
 
-    });
+    })
 
     describe("returned vote", function () {
       it("should be ok", function () {
-        (vt).should.be.ok;
-      });
+        (vt).should.be.ok
+      })
 
       it("should be object", function () {
-        (vt).should.be.type("object");
-      });
+        (vt).should.be.type("object")
+      })
 
       it("should have recipientId string equal to sender", function () {
         (vt).should.have.property("recipientId").and.be.type("string").and.equal(ark.crypto.getAddress(publicKey))
-      });
+      })
 
       it("should have amount number equal to 0", function () {
-        (vt).should.have.property("amount").and.be.type("number").and.equal(0);
-      });
+        (vt).should.have.property("amount").and.be.type("number").and.equal(0)
+      })
 
       it("should have type number equal to 3", function () {
-        (vt).should.have.property("type").and.be.type("number").and.equal(3);
-      });
+        (vt).should.have.property("type").and.be.type("number").and.equal(3)
+      })
 
       it("should have timestamp number", function () {
-        (vt).should.have.property("timestamp").and.be.type("number");
-      });
+        (vt).should.have.property("timestamp").and.be.type("number")
+      })
 
       it("should have senderPublicKey hex string equal to sender public key", function () {
         (vt).should.have.property("senderPublicKey").and.be.type("string").and.match(function () {
           try {
-            new Buffer(vt.senderPublicKey, "hex");
+            new Buffer(vt.senderPublicKey, "hex")
           } catch (e) {
-            return false;
+            return false
           }
 
-          return true;
-        }).and.equal(publicKey);
-      });
+          return true
+        }).and.equal(publicKey)
+      })
 
       it("should have signature hex string", function () {
         (vt).should.have.property("signature").and.be.type("string").and.match(function () {
           try {
-            new Buffer(vt.signature, "hex");
+            new Buffer(vt.signature, "hex")
           } catch (e) {
-            return false;
+            return false
           }
 
-          return true;
-        });
-      });
+          return true
+        })
+      })
 
       it("should have second signature hex string", function () {
         (vt).should.have.property("signSignature").and.be.type("string").and.match(function () {
           try {
-            new Buffer(vt.signSignature, "hex");
+            new Buffer(vt.signSignature, "hex")
           } catch (e) {
-            return false;
+            return false
           }
 
-          return true;
-        });
-      });
+          return true
+        })
+      })
 
       it("should be signed correctly", function () {
         var result = ark.crypto.verify(vt);
-        (result).should.be.ok;
-      });
+        (result).should.be.ok
+      })
 
       it("should be second signed correctly", function () {
         var result = ark.crypto.verifySecondSignature(vt, ark.crypto.getKeys("second secret").publicKey);
-        (result).should.be.ok;
-      });
+        (result).should.be.ok
+      })
 
       it("should not be signed correctly now", function () {
-        vt.amount = 100;
+        vt.amount = 100
         var result = ark.crypto.verify(vt);
-        (result).should.be.not.ok;
-      });
+        (result).should.be.not.ok
+      })
 
       it("should not be second signed correctly now", function () {
-        vt.amount = 100;
+        vt.amount = 100
         var result = ark.crypto.verifySecondSignature(vt, ark.crypto.getKeys("second secret").publicKey);
-        (result).should.be.not.ok;
-      });
+        (result).should.be.not.ok
+      })
 
       it("should have asset", function () {
-        (vt).should.have.property("asset").and.not.empty;
-      });
+        (vt).should.have.property("asset").and.not.empty
+      })
 
       describe("vote asset", function () {
         it("should be ok", function () {
-          (vt.asset).should.have.property("votes").and.be.ok;
-        });
+          (vt.asset).should.have.property("votes").and.be.ok
+        })
 
         it("should be object", function () {
-          (vt.asset.votes).should.be.type("object");
-        });
+          (vt.asset.votes).should.be.type("object")
+        })
 
         it("should be not empty", function () {
-          (vt.asset.votes).should.be.not.empty;
-        });
+          (vt.asset.votes).should.be.not.empty
+        })
 
         it("should contains one element", function () {
-          (vt.asset.votes.length).should.be.equal(1);
-        });
+          (vt.asset.votes.length).should.be.equal(1)
+        })
 
         it("should have public keys in hex", function () {
           vt.asset.votes.forEach(function (v) {
             (v).should.be.type("string").startWith("+").and.match(function () {
               try {
-                new Buffer(v.substring(1, v.length), "hex");
+                new Buffer(v.substring(1, v.length), "hex")
               } catch (e) {
-                return false;
+                return false
               }
 
-              return true;
-            });
-          });
-        });
+              return true
+            })
+          })
+        })
 
         it("should be equal to sender public key", function () {
           var v = vt.asset.votes[0];
-          (v.substring(1, v.length)).should.be.equal(publicKey);
-        });
+          (v.substring(1, v.length)).should.be.equal(publicKey)
+        })
       })
-    });
-  });
+    })
+  })
 
-});
+})


### PR DESCRIPTION
Normalize semicolon usage and enforce with rules. It's based on the existing codebase and the Javascript Standard Style and mostly affects inconsistencies with the test code. **Dependent on PR #15.**