### PR TITLE
Convert var into let & const

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,10 @@
 {
   "env": {
     "browser": true,
-    "mocha": true,
     "node": true
   },
   "extends": [
-    "eslint:recommended",
+    "eslint:recommended"
   ],
   "rules": {
     "func-names": ["error", "never"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,8 +6,13 @@
   "extends": [
     "eslint:recommended"
   ],
+  "parserOptions": {
+    "ecmaVersion": 6
+  },
   "rules": {
     "func-names": ["error", "never"],
-    "max-len": ["error", 140, { "ignoreComments": true }]
+    "max-len": ["error", 140, { "ignoreComments": true }],
+    "no-var": "error",
+    "prefer-const": "warn"
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ before_script:
   - npm install
 
 script:
-  #- npm run lint
+  - npm run lint
   - npm run test

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-ark = {
+var ark = {
 	crypto : require("./lib/transactions/crypto.js"),
 	delegate : require("./lib/transactions/delegate.js"),
 	signature : require("./lib/transactions/signature.js"),

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /** @module arkjs */
 
-var ark = {
+const ark = {
 	crypto : require("./lib/transactions/crypto.js"),
 	delegate : require("./lib/transactions/delegate.js"),
 	signature : require("./lib/transactions/signature.js"),
@@ -17,8 +17,8 @@ var ark = {
 }
 
 // extra aliases for bitcoinlib-js compatibility
-var libCrypto = require('./lib/crypto.js')
-for (var method in libCrypto) {
+const libCrypto = require('./lib/crypto.js')
+for (const method in libCrypto) {
 	ark.crypto[method] = libCrypto[method]
 }
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -1,4 +1,4 @@
-var createHash = require('create-hash')
+const createHash = require('create-hash')
 
 /**
  * @param {string|Buffer} buffer

--- a/lib/ecdsa.js
+++ b/lib/ecdsa.js
@@ -1,15 +1,15 @@
-var createHmac = require('create-hmac')
-var typeforce = require('typeforce')
-var types = require('./types')
+const createHmac = require('create-hmac')
+const typeforce = require('typeforce')
+const types = require('./types')
 
-var BigInteger = require('bigi')
-var ECSignature = require('./ecsignature')
+const BigInteger = require('bigi')
+const ECSignature = require('./ecsignature')
 
-var ZERO = new Buffer([0])
-var ONE = new Buffer([1])
+const ZERO = new Buffer([0])
+const ONE = new Buffer([1])
 
-var ecurve = require('ecurve')
-var secp256k1 = ecurve.getCurveByName('secp256k1')
+const ecurve = require('ecurve')
+const secp256k1 = ecurve.getCurveByName('secp256k1')
 
 /**
  * https://tools.ietf.org/html/rfc6979#section-3.2
@@ -26,8 +26,8 @@ function deterministicGenerateK (hash, x, checkSig) {
     types.Function
   ), arguments)
 
-  var k = new Buffer(32)
-  var v = new Buffer(32)
+  let k = new Buffer(32)
+  let v = new Buffer(32)
 
   // Step A, ignored as hash already provided
   // Step B
@@ -62,7 +62,7 @@ function deterministicGenerateK (hash, x, checkSig) {
   // Step H2b
   v = createHmac('sha256', k).update(v).digest()
 
-  var T = BigInteger.fromBuffer(v)
+  let T = BigInteger.fromBuffer(v)
 
   // Step H3, repeat until T is within the interval [1, n - 1] and is suitable for ECDSA
   while (T.signum() <= 0 || T.compareTo(secp256k1.n) >= 0 || !checkSig(T)) {
@@ -82,7 +82,7 @@ function deterministicGenerateK (hash, x, checkSig) {
   return T
 }
 
-var N_OVER_TWO = secp256k1.n.shiftRight(1)
+const N_OVER_TWO = secp256k1.n.shiftRight(1)
 
 /**
  * @param {Buffer} hash
@@ -92,14 +92,14 @@ var N_OVER_TWO = secp256k1.n.shiftRight(1)
 function sign (hash, d) {
   typeforce(types.tuple(types.Hash256bit, types.BigInt), arguments)
 
-  var x = d.toBuffer(32)
-  var e = BigInteger.fromBuffer(hash)
-  var n = secp256k1.n
-  var G = secp256k1.G
+  const x = d.toBuffer(32)
+  const e = BigInteger.fromBuffer(hash)
+  const n = secp256k1.n
+  const G = secp256k1.G
 
-  var r, s
+  let r, s
   deterministicGenerateK(hash, x, function (k) {
-    var Q = G.multiply(k)
+    const Q = G.multiply(k)
 
     if (secp256k1.isInfinity(Q)) return false
 
@@ -132,11 +132,11 @@ function verify (hash, signature, Q) {
     types.ECPoint
   ), arguments)
 
-  var n = secp256k1.n
-  var G = secp256k1.G
+  const n = secp256k1.n
+  const G = secp256k1.G
 
-  var r = signature.r
-  var s = signature.s
+  const r = signature.r
+  const s = signature.s
 
   // 1.4.1 Enforce r and s are both integers in the interval [1, n − 1]
   if (r.signum() <= 0 || r.compareTo(n) >= 0) return false
@@ -144,28 +144,28 @@ function verify (hash, signature, Q) {
 
   // 1.4.2 H = Hash(M), already done by the user
   // 1.4.3 e = H
-  var e = BigInteger.fromBuffer(hash)
+  const e = BigInteger.fromBuffer(hash)
 
   // Compute s^-1
-  var sInv = s.modInverse(n)
+  const sInv = s.modInverse(n)
 
   // 1.4.4 Compute u1 = es^−1 mod n
   //               u2 = rs^−1 mod n
-  var u1 = e.multiply(sInv).mod(n)
-  var u2 = r.multiply(sInv).mod(n)
+  const u1 = e.multiply(sInv).mod(n)
+  const u2 = r.multiply(sInv).mod(n)
 
   // 1.4.5 Compute R = (xR, yR)
   //               R = u1G + u2Q
-  var R = G.multiplyTwo(u1, Q, u2)
+  const R = G.multiplyTwo(u1, Q, u2)
 
   // 1.4.5 (cont.) Enforce R is not at infinity
   if (secp256k1.isInfinity(R)) return false
 
   // 1.4.6 Convert the field element R.x to an integer
-  var xR = R.affineX
+  const xR = R.affineX
 
   // 1.4.7 Set v = xR mod n
-  var v = xR.mod(n)
+  const v = xR.mod(n)
 
   // 1.4.8 If v = r, output "valid", and if v != r, output "invalid"
   return v.equals(r)

--- a/lib/ecpair.js
+++ b/lib/ecpair.js
@@ -1,18 +1,18 @@
-var base58check = require('bs58check')
-var bcrypto = require('./crypto')
-var ECSignature = require('./ecsignature')
-var randomBytes = require('randombytes')
-var typeforce = require('typeforce')
-var types = require('./types')
-var wif = require('wif')
+const base58check = require('bs58check')
+const bcrypto = require('./crypto')
+const ECSignature = require('./ecsignature')
+const randomBytes = require('randombytes')
+const typeforce = require('typeforce')
+const types = require('./types')
+const wif = require('wif')
 
-var NETWORKS = require('./networks')
-var BigInteger = require('bigi')
+const NETWORKS = require('./networks')
+const BigInteger = require('bigi')
 
-var ecurve = require('ecurve')
-var secp256k1 = ecurve.getCurveByName('secp256k1')
+const ecurve = require('ecurve')
+const secp256k1 = ecurve.getCurveByName('secp256k1')
 
-var secp256k1native = require('secp256k1')
+const secp256k1native = require('secp256k1')
 
 /**
  * @class
@@ -62,7 +62,7 @@ Object.defineProperty(ECPair.prototype, 'Q', {
  * @returns {ECPair}
  */
 ECPair.fromPublicKeyBuffer = function (buffer, network) {
-  var Q = ecurve.Point.decodeFrom(secp256k1, buffer)
+  const Q = ecurve.Point.decodeFrom(secp256k1, buffer)
 
   return new ECPair(null, Q, {
     compressed: Q.compressed,
@@ -74,8 +74,8 @@ ECPair.fromPublicKeyBuffer = function (buffer, network) {
  * @param {string} string
  */
 ECPair.fromWIF = function (string, network) {
-  var decoded = wif.decode(string)
-  var version = decoded.version
+  const decoded = wif.decode(string)
+  const version = decoded.version
 
   // [network, ...]
   if (types.Array(network)) {
@@ -92,7 +92,7 @@ ECPair.fromWIF = function (string, network) {
     if (version !== network.wif) throw new Error('Invalid network version')
   }
 
-  var d = BigInteger.fromBuffer(decoded.privateKey)
+  const d = BigInteger.fromBuffer(decoded.privateKey)
 
   return new ECPair(d, null, {
     compressed: decoded.compressed,
@@ -106,11 +106,11 @@ ECPair.fromWIF = function (string, network) {
 ECPair.makeRandom = function (options) {
   options = options || {}
 
-  var rng = options.rng || randomBytes
+  const rng = options.rng || randomBytes
 
-  var d
+  let d
   do {
-    var buffer = rng(32)
+    const buffer = rng(32)
     typeforce(types.Buffer256bit, buffer)
 
     d = BigInteger.fromBuffer(buffer)
@@ -126,8 +126,8 @@ ECPair.makeRandom = function (options) {
  * @throws {Error}
  */
 ECPair.fromSeed = function(seed, options) {
-  var hash = bcrypto.sha256(new Buffer(seed,"utf-8"))
-  var d = BigInteger.fromBuffer(hash)
+  const hash = bcrypto.sha256(new Buffer(seed,"utf-8"))
+  const d = BigInteger.fromBuffer(hash)
   if(d.signum() <= 0 || d.compareTo(secp256k1.n) >= 0){
     throw new Error("seed cannot resolve to a compatible private key")
   }
@@ -140,9 +140,9 @@ ECPair.fromSeed = function(seed, options) {
  * @returns {string}
  */
 ECPair.prototype.getAddress = function () {
-  var payload = new Buffer(21)
-  var hash = bcrypto.ripemd160(this.getPublicKeyBuffer())
-  var version = this.getNetwork().pubKeyHash
+  const payload = new Buffer(21)
+  const hash = bcrypto.ripemd160(this.getPublicKeyBuffer())
+  const version = this.getNetwork().pubKeyHash
   payload.writeUInt8(version, 0)
   hash.copy(payload, 1)
 
@@ -162,7 +162,7 @@ ECPair.prototype.getPublicKeyBuffer = function () {
  */
 ECPair.prototype.sign = function (hash) {
   if (!this.d) throw new Error('Missing private key')
-  var native=secp256k1native.sign(hash, this.d.toBuffer(32))
+  const native=secp256k1native.sign(hash, this.d.toBuffer(32))
   return ECSignature.parseNativeSecp256k1(native).signature
 }
 

--- a/lib/ecpair.js
+++ b/lib/ecpair.js
@@ -1,6 +1,5 @@
 var base58check = require('bs58check')
 var bcrypto = require('./crypto')
-var ecdsa = require('./ecdsa')
 var ECSignature = require('./ecsignature')
 var randomBytes = require('randombytes')
 var typeforce = require('typeforce')

--- a/lib/ecsignature.js
+++ b/lib/ecsignature.js
@@ -29,7 +29,7 @@ ECSignature.parseNativeSecp256k1 = function (native) {
 
 ECSignature.prototype.toNativeSecp256k1 = function () {
   var buffer = new Buffer(64)
-  if(this.r.toBuffer().length > 32 || this.s.toBuffer().length > 32){
+  if(this.r.toBuffer().length > 32 || this.s.toBuffer().length > 32){
     return buffer;
   }
 

--- a/lib/ecsignature.js
+++ b/lib/ecsignature.js
@@ -1,8 +1,8 @@
-var bip66 = require('bip66')
-var typeforce = require('typeforce')
-var types = require('./types')
+const bip66 = require('bip66')
+const typeforce = require('typeforce')
+const types = require('./types')
 
-var BigInteger = require('bigi')
+const BigInteger = require('bigi')
 
 /**
  * Creates a new ECSignature.
@@ -21,11 +21,11 @@ function ECSignature (r, s) {
 ECSignature.parseNativeSecp256k1 = function (native) {
   if (native.signature.length !== 64) throw new Error('Invalid signature length')
 
-  var compressed = 0
-  var recoveryParam = native.recovery
+  const compressed = 0
+  const recoveryParam = native.recovery
 
-  var r = BigInteger.fromBuffer(native.signature.slice(0, 32))
-  var s = BigInteger.fromBuffer(native.signature.slice(32))
+  const r = BigInteger.fromBuffer(native.signature.slice(0, 32))
+  const s = BigInteger.fromBuffer(native.signature.slice(32))
 
   return {
     compressed: compressed,
@@ -38,7 +38,7 @@ ECSignature.parseNativeSecp256k1 = function (native) {
  * @returns {Buffer}
  */
 ECSignature.prototype.toNativeSecp256k1 = function () {
-  var buffer = new Buffer(64)
+  const buffer = new Buffer(64)
   if(this.r.toBuffer().length > 32 || this.s.toBuffer().length > 32){
     return buffer;
   }
@@ -55,14 +55,14 @@ ECSignature.prototype.toNativeSecp256k1 = function () {
 ECSignature.parseCompact = function (buffer) {
   if (buffer.length !== 65) throw new Error('Invalid signature length')
 
-  var flagByte = buffer.readUInt8(0) - 27
+  const flagByte = buffer.readUInt8(0) - 27
   if (flagByte !== (flagByte & 7)) throw new Error('Invalid signature parameter')
 
-  var compressed = !!(flagByte & 4)
-  var recoveryParam = flagByte & 3
+  const compressed = !!(flagByte & 4)
+  const recoveryParam = flagByte & 3
 
-  var r = BigInteger.fromBuffer(buffer.slice(1, 33))
-  var s = BigInteger.fromBuffer(buffer.slice(33))
+  const r = BigInteger.fromBuffer(buffer.slice(1, 33))
+  const s = BigInteger.fromBuffer(buffer.slice(33))
 
   return {
     compressed: compressed,
@@ -76,9 +76,9 @@ ECSignature.parseCompact = function (buffer) {
  * @returns {ECSignature}
  */
 ECSignature.fromDER = function (buffer) {
-  var decode = bip66.decode(buffer)
-  var r = BigInteger.fromDERInteger(decode.r)
-  var s = BigInteger.fromDERInteger(decode.s)
+  const decode = bip66.decode(buffer)
+  const r = BigInteger.fromDERInteger(decode.r)
+  const s = BigInteger.fromDERInteger(decode.s)
 
   return new ECSignature(r, s)
 }
@@ -89,8 +89,8 @@ ECSignature.fromDER = function (buffer) {
  * @param {Buffer} buffer
  */
 ECSignature.parseScriptSignature = function (buffer) {
-  var hashType = buffer.readUInt8(buffer.length - 1)
-  var hashTypeMod = hashType & ~0x80
+  const hashType = buffer.readUInt8(buffer.length - 1)
+  const hashTypeMod = hashType & ~0x80
 
   if (hashTypeMod <= 0x00 || hashTypeMod >= 0x04) throw new Error('Invalid hashType ' + hashType)
 
@@ -112,7 +112,7 @@ ECSignature.prototype.toCompact = function (i, compressed) {
 
   i += 27
 
-  var buffer = new Buffer(65)
+  const buffer = new Buffer(65)
   buffer.writeUInt8(i, 0)
 
   this.r.toBuffer(32).copy(buffer, 1)
@@ -125,8 +125,8 @@ ECSignature.prototype.toCompact = function (i, compressed) {
  * @return {Buffer}
  */
 ECSignature.prototype.toDER = function () {
-  var r = new Buffer(this.r.toDERInteger())
-  var s = new Buffer(this.s.toDERInteger())
+  const r = new Buffer(this.r.toDERInteger())
+  const s = new Buffer(this.s.toDERInteger())
 
   return bip66.encode(r, s)
 }
@@ -136,10 +136,10 @@ ECSignature.prototype.toDER = function () {
  * @returns {Buffer}
  */
 ECSignature.prototype.toScriptSignature = function (hashType) {
-  var hashTypeMod = hashType & ~0x80
+  const hashTypeMod = hashType & ~0x80
   if (hashTypeMod <= 0 || hashTypeMod >= 4) throw new Error('Invalid hashType ' + hashType)
 
-  var hashTypeBuffer = new Buffer(1)
+  const hashTypeBuffer = new Buffer(1)
   hashTypeBuffer.writeUInt8(hashType, 0)
 
   return Buffer.concat([this.toDER(), hashTypeBuffer])

--- a/lib/hdnode.js
+++ b/lib/hdnode.js
@@ -1,15 +1,15 @@
-var base58check = require('bs58check')
-var bcrypto = require('./crypto')
-var createHmac = require('create-hmac')
-var typeforce = require('typeforce')
-var types = require('./types')
-var NETWORKS = require('./networks')
+const base58check = require('bs58check')
+const bcrypto = require('./crypto')
+const createHmac = require('create-hmac')
+const typeforce = require('typeforce')
+const types = require('./types')
+const NETWORKS = require('./networks')
 
-var BigInteger = require('bigi')
-var ECPair = require('./ecpair')
+const BigInteger = require('bigi')
+const ECPair = require('./ecpair')
 
-var ecurve = require('ecurve')
-var curve = ecurve.getCurveByName('secp256k1')
+const ecurve = require('ecurve')
+const curve = ecurve.getCurveByName('secp256k1')
 
 /**
  * @class
@@ -40,14 +40,14 @@ HDNode.fromSeedBuffer = function (seed, network) {
   if (seed.length < 16) throw new TypeError('Seed should be at least 128 bits')
   if (seed.length > 64) throw new TypeError('Seed should be at most 512 bits')
 
-  var I = createHmac('sha512', HDNode.MASTER_SECRET).update(seed).digest()
-  var IL = I.slice(0, 32)
-  var IR = I.slice(32)
+  const I = createHmac('sha512', HDNode.MASTER_SECRET).update(seed).digest()
+  const IL = I.slice(0, 32)
+  const IR = I.slice(32)
 
   // In case IL is 0 or >= n, the master key is invalid
   // This is handled by the ECPair constructor
-  var pIL = BigInteger.fromBuffer(IL)
-  var keyPair = new ECPair(pIL, null, {
+  const pIL = BigInteger.fromBuffer(IL)
+  const keyPair = new ECPair(pIL, null, {
     network: network
   })
 
@@ -66,12 +66,12 @@ HDNode.fromSeedHex = function (hex, network) {
  * @returns {HDNode}
  */
 HDNode.fromBase58 = function (string, networks) {
-  var buffer = base58check.decode(string)
+  const buffer = base58check.decode(string)
   if (buffer.length !== 78) throw new Error('Invalid buffer length')
 
   // 4 bytes: version bytes
-  var version = buffer.readUInt32BE(0)
-  var network
+  const version = buffer.readUInt32BE(0)
+  let network
 
   // list of networks?
   if (Array.isArray(networks)) {
@@ -91,33 +91,33 @@ HDNode.fromBase58 = function (string, networks) {
     version !== network.bip32.public) throw new Error('Invalid network version')
 
   // 1 byte: depth: 0x00 for master nodes, 0x01 for level-1 descendants, ...
-  var depth = buffer[4]
+  const depth = buffer[4]
 
   // 4 bytes: the fingerprint of the parent's key (0x00000000 if master key)
-  var parentFingerprint = buffer.readUInt32BE(5)
+  const parentFingerprint = buffer.readUInt32BE(5)
   if (depth === 0) {
     if (parentFingerprint !== 0x00000000) throw new Error('Invalid parent fingerprint')
   }
 
   // 4 bytes: child number. This is the number i in xi = xpar/i, with xi the key being serialized.
   // This is encoded in MSB order. (0x00000000 if master key)
-  var index = buffer.readUInt32BE(9)
+  const index = buffer.readUInt32BE(9)
   if (depth === 0 && index !== 0) throw new Error('Invalid index')
 
   // 32 bytes: the chain code
-  var chainCode = buffer.slice(13, 45)
-  var keyPair
+  const chainCode = buffer.slice(13, 45)
+  let keyPair
 
   // 33 bytes: private key data (0x00 + k)
   if (version === network.bip32.private) {
     if (buffer.readUInt8(45) !== 0x00) throw new Error('Invalid private key')
 
-    var d = BigInteger.fromBuffer(buffer.slice(46, 78))
+    const d = BigInteger.fromBuffer(buffer.slice(46, 78))
     keyPair = new ECPair(d, null, { network: network })
 
   // 33 bytes: public key data (0x02 + X or 0x03 + X)
   } else {
-    var Q = ecurve.Point.decodeFrom(curve, buffer.slice(45, 78))
+    const Q = ecurve.Point.decodeFrom(curve, buffer.slice(45, 78))
     // Q.compressed is assumed, if somehow this assumption is broken, `new HDNode` will throw
 
     // Verify that the X coordinate in the public point corresponds to a point on the curve.
@@ -127,7 +127,7 @@ HDNode.fromBase58 = function (string, networks) {
     keyPair = new ECPair(null, Q, { network: network })
   }
 
-  var hd = new HDNode(keyPair, chainCode)
+  const hd = new HDNode(keyPair, chainCode)
   hd.depth = depth
   hd.index = index
   hd.parentFingerprint = parentFingerprint
@@ -168,11 +168,11 @@ HDNode.prototype.getPublicKeyBuffer = function () {
  * @returns {HDNode}
  */
 HDNode.prototype.neutered = function () {
-  var neuteredKeyPair = new ECPair(null, this.keyPair.Q, {
+  const neuteredKeyPair = new ECPair(null, this.keyPair.Q, {
     network: this.keyPair.network
   })
 
-  var neutered = new HDNode(neuteredKeyPair, this.chainCode)
+  const neutered = new HDNode(neuteredKeyPair, this.chainCode)
   neutered.depth = this.depth
   neutered.index = this.index
   neutered.parentFingerprint = this.parentFingerprint
@@ -193,9 +193,9 @@ HDNode.prototype.verify = function (hash, signature) {
  */
 HDNode.prototype.toBase58 = function () {
   // Version
-  var network = this.keyPair.network
-  var version = (!this.isNeutered()) ? network.bip32.private : network.bip32.public
-  var buffer = new Buffer(78)
+  const network = this.keyPair.network
+  const version = (!this.isNeutered()) ? network.bip32.private : network.bip32.public
+  const buffer = new Buffer(78)
 
   // 4 bytes: version bytes
   buffer.writeUInt32BE(version, 0)
@@ -237,8 +237,8 @@ HDNode.prototype.toBase58 = function () {
 HDNode.prototype.derive = function (index) {
   typeforce(types.UInt32, index)
 
-  var isHardened = index >= HDNode.HIGHEST_BIT
-  var data = new Buffer(37)
+  const isHardened = index >= HDNode.HIGHEST_BIT
+  const data = new Buffer(37)
 
   // Hardened child
   if (isHardened) {
@@ -257,11 +257,11 @@ HDNode.prototype.derive = function (index) {
     data.writeUInt32BE(index, 33)
   }
 
-  var I = createHmac('sha512', this.chainCode).update(data).digest()
-  var IL = I.slice(0, 32)
-  var IR = I.slice(32)
+  const I = createHmac('sha512', this.chainCode).update(data).digest()
+  const IL = I.slice(0, 32)
+  const IR = I.slice(32)
 
-  var pIL = BigInteger.fromBuffer(IL)
+  const pIL = BigInteger.fromBuffer(IL)
 
   // In case parse256(IL) >= n, proceed with the next value for i
   if (pIL.compareTo(curve.n) >= 0) {
@@ -269,10 +269,10 @@ HDNode.prototype.derive = function (index) {
   }
 
   // Private parent key -> private child key
-  var derivedKeyPair
+  let derivedKeyPair
   if (!this.isNeutered()) {
     // ki = parse256(IL) + kpar (mod n)
-    var ki = pIL.add(this.keyPair.d).mod(curve.n)
+    const ki = pIL.add(this.keyPair.d).mod(curve.n)
 
     // In case ki == 0, proceed with the next value for i
     if (ki.signum() === 0) {
@@ -287,7 +287,7 @@ HDNode.prototype.derive = function (index) {
   } else {
     // Ki = point(parse256(IL)) + Kpar
     //    = G*IL + Kpar
-    var Ki = curve.G.multiply(pIL).add(this.keyPair.Q)
+    const Ki = curve.G.multiply(pIL).add(this.keyPair.Q)
 
     // In case Ki is the point at infinity, proceed with the next value for i
     if (curve.isInfinity(Ki)) {
@@ -299,7 +299,7 @@ HDNode.prototype.derive = function (index) {
     })
   }
 
-  var hd = new HDNode(derivedKeyPair, IR)
+  const hd = new HDNode(derivedKeyPair, IR)
   hd.depth = this.depth + 1
   hd.index = index
   hd.parentFingerprint = this.getFingerprint().readUInt32BE(0)
@@ -335,7 +335,7 @@ HDNode.prototype.isNeutered = function () {
 HDNode.prototype.derivePath = function (path) {
   typeforce(types.BIP32Path, path)
 
-  var splitPath = path.split('/')
+  let splitPath = path.split('/')
   if (splitPath[0] === 'm') {
     if (this.parentFingerprint) {
       throw new Error('Not a master node')
@@ -345,7 +345,7 @@ HDNode.prototype.derivePath = function (path) {
   }
 
   return splitPath.reduce(function (prevHd, indexStr) {
-    var index
+    let index
     if (indexStr.slice(-1) === "'") {
       index = parseInt(indexStr.slice(0, -1), 10)
       return prevHd.deriveHardened(index)

--- a/lib/time/slots.js
+++ b/lib/time/slots.js
@@ -6,8 +6,8 @@ function getEpochTime(time) {
 	if (time === undefined) {
 		time = (new Date()).getTime();
 	}
-	var d = beginEpochTime();
-	var t = d.getTime();
+	const d = beginEpochTime();
+	const t = d.getTime();
 	return Math.floor((time - t) / 1000);
 }
 
@@ -15,13 +15,13 @@ function getEpochTime(time) {
  * @returns {Date}
  */
 function beginEpochTime() {
-	var d = new Date(Date.UTC(2017,2,21,13,0,0,0))
+	const d = new Date(Date.UTC(2017,2,21,13,0,0,0))
 
 	return d;
 }
 
-var interval = 8,
-    delegates = 51;
+const interval = 8,
+      delegates = 51;
 
 /**
  * @param {Date=} time
@@ -39,8 +39,8 @@ function getRealTime(epochTime) {
 	if (epochTime === undefined) {
 		epochTime = getTime()
 	}
-	var d = beginEpochTime();
-	var t = Math.floor(d.getTime() / 1000) * 1000;
+	const d = beginEpochTime();
+	const t = Math.floor(d.getTime() / 1000) * 1000;
 	return t + epochTime * 1000;
 }
 
@@ -68,7 +68,7 @@ function getSlotTime(slot) {
  * @returns {number}
  */
 function getNextSlot() {
-	var slot = getSlotNumber();
+	const slot = getSlotNumber();
 
 	return slot + 1;
 }

--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -7,12 +7,10 @@ var networks = require("../networks.js")
 var bs58check = require('bs58check')
 
 if (typeof Buffer === "undefined") {
-	Buffer = require("buffer/").Buffer;
+	Buffer = require("buffer/").Buffer; // eslint-disable-line no-global-assign
 }
 
 var ByteBuffer = require("bytebuffer");
-var bignum = require("browserify-bignum");
-
 
 var fixedPoint = Math.pow(10, 8);
 // default is ark mainnet
@@ -27,7 +25,7 @@ function getSignatureBytes(signature) {
 	}
 
 	bb.flip();
-	return new Uint8Array(bb.toArrayBuffer());
+	return new Uint8Array(bb.toArrayBuffer()); // eslint-disable-line no-undef
 }
 
 function getBytes(transaction, skipSignature, skipSecondSignature) {
@@ -71,22 +69,22 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 
 	}
 
-	var bb = new ByteBuffer(1 + 4 + 32 + 8 + 8 + 21 + 64 + 64 + 64 + assetSize, true);
+	bb = new ByteBuffer(1 + 4 + 32 + 8 + 8 + 21 + 64 + 64 + 64 + assetSize, true);
 	bb.writeByte(transaction.type);
 	bb.writeInt(transaction.timestamp);
 
 	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
-	for (var i = 0; i < senderPublicKeyBuffer.length; i++) {
+	for (i = 0; i < senderPublicKeyBuffer.length; i++) {
 		bb.writeByte(senderPublicKeyBuffer[i]);
 	}
 
 	if (transaction.recipientId) {
 		var recipient = bs58check.decode(transaction.recipientId);
-		for (var i = 0; i < recipient.length; i++) {
+		for (i = 0; i < recipient.length; i++) {
 			bb.writeByte(recipient[i]);
 		}
 	} else {
-		for (var i = 0; i < 21; i++) {
+		for (i = 0; i < 21; i++) {
 			bb.writeByte(0);
 		}
 	}
@@ -102,8 +100,8 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 		}
 	}
 	else if (transaction.vendorField) {
-		var vf = new Buffer(transaction.vendorField);
-		var fillstart=vf.length;
+		vf = new Buffer(transaction.vendorField);
+		fillstart=vf.length;
 		for (i = 0; i < fillstart; i++) {
 			bb.writeByte(vf[i]);
 		}
@@ -121,30 +119,30 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 	bb.writeLong(transaction.fee);
 
 	if (assetSize > 0) {
-		for (var i = 0; i < assetSize; i++) {
+		for (i = 0; i < assetSize; i++) {
 			bb.writeByte(assetBytes[i]);
 		}
 	}
 
 	if (!skipSignature && transaction.signature) {
 		var signatureBuffer = new Buffer(transaction.signature, "hex");
-		for (var i = 0; i < signatureBuffer.length; i++) {
+		for (i = 0; i < signatureBuffer.length; i++) {
 			bb.writeByte(signatureBuffer[i]);
 		}
 	}
 
 	if (!skipSecondSignature && transaction.signSignature) {
 		var signSignatureBuffer = new Buffer(transaction.signSignature, "hex");
-		for (var i = 0; i < signSignatureBuffer.length; i++) {
+		for (i = 0; i < signSignatureBuffer.length; i++) {
 			bb.writeByte(signSignatureBuffer[i]);
 		}
 	}
 
 	bb.flip();
-	var arrayBuffer = new Uint8Array(bb.toArrayBuffer());
+	var arrayBuffer = new Uint8Array(bb.toArrayBuffer()); // eslint-disable-line no-undef
 	var buffer = [];
 
-	for (var i = 0; i < arrayBuffer.length; i++) {
+	for (i = 0; i < arrayBuffer.length; i++) {
 		buffer[i] = arrayBuffer[i];
 	}
 
@@ -176,7 +174,7 @@ function fromBytes(hexString){
 	else if(tx.type == 2){ // delegate registration
 		delete tx.recipientId;
 		// Impossible to assess size of delegate asset, trying to grab signature and derive delegate asset
-		var offset = findAndParseSignatures(hexString, tx);
+		offset = findAndParseSignatures(hexString, tx);
 
 		tx.asset = {
 			delegate: {
@@ -193,7 +191,7 @@ function fromBytes(hexString){
 	}
 	else if(tx.type == 4){ // multisignature creation
 		delete tx.recipientId;
-		var offset = findAndParseSignatures(hexString, tx);
+		offset = findAndParseSignatures(hexString, tx);
 		var buffer = new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex")
 		tx.asset = {
 			multisignature: {}
@@ -212,7 +210,7 @@ function fromBytes(hexString){
 		delete tx.recipientId;
 		parseSignatures(hexString, tx, 76+42+128+32);
 	}
-	console.log(tx);
+	//console.log(tx);
 	return tx;
 }
 
@@ -236,10 +234,10 @@ function findAndParseSignatures(hexString, tx){
 		offset = 0;
 		signature1 = null;
 	}
-	else {
+	else {
 		found = false;
 		offset = signature1.length*2;
-		var signature2 = new Buffer(hexString.substring(hexString.length-offset-146, hexString.length-offset), "hex");
+		signature2 = new Buffer(hexString.substring(hexString.length-offset-146, hexString.length-offset), "hex");
 		while(!found && signature2.length > 8){
 			if(signature2[0] != 0x30){
 				signature2 = signature2.slice(1);
@@ -288,19 +286,15 @@ function getFee(transaction) {
 	switch (transaction.type) {
 		case 0: // Normal
 			return 0.1 * fixedPoint;
-			break;
 
 		case 1: // Signature
 			return 100 * fixedPoint;
-			break;
 
 		case 2: // Delegate
 			return 10000 * fixedPoint;
-			break;
 
 		case 3: // Vote
 			return 1 * fixedPoint;
-			break;
 	}
 }
 

--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -1,30 +1,30 @@
-var crypto = require("crypto");
-var crypto_utils = require("../crypto.js");
-var ECPair = require("../ecpair.js");
-var ECSignature = require("../ecsignature.js");
-var networks = require("../networks.js")
+const crypto = require("crypto");
+const crypto_utils = require("../crypto.js");
+const ECPair = require("../ecpair.js");
+const ECSignature = require("../ecsignature.js");
+const networks = require("../networks.js")
 
-var bs58check = require('bs58check')
+const bs58check = require('bs58check')
 
 if (typeof Buffer === "undefined") {
 	Buffer = require("buffer/").Buffer; // eslint-disable-line no-global-assign
 }
 
-var ByteBuffer = require("bytebuffer");
+const ByteBuffer = require("bytebuffer");
 
-var fixedPoint = Math.pow(10, 8);
+const fixedPoint = Math.pow(10, 8);
 // default is ark mainnet
-var networkVersion = 0x17;
+let networkVersion = 0x17;
 
 function isECPair(obj) {
 	return obj instanceof ECPair;
 }
 
 function getSignatureBytes(signature) {
-	var bb = new ByteBuffer(33, true);
-	var publicKeyBuffer = new Buffer(signature.publicKey, "hex");
+	const bb = new ByteBuffer(33, true);
+	const publicKeyBuffer = new Buffer(signature.publicKey, "hex");
 
-	for (var i = 0; i < publicKeyBuffer.length; i++) {
+	for (let i = 0; i < publicKeyBuffer.length; i++) {
 		bb.writeByte(publicKeyBuffer[i]);
 	}
 
@@ -33,9 +33,10 @@ function getSignatureBytes(signature) {
 }
 
 function getBytes(transaction, skipSignature, skipSecondSignature) {
-	var assetSize = 0,
-		assetBytes = null;
+	let assetSize = 0,
+      assetBytes = null;
 
+	let keysgroupBuffer, bb
 	switch (transaction.type) {
 		case 1: // Signature
 			assetBytes = getSignatureBytes(transaction.asset.signature);
@@ -55,13 +56,13 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 			break;
 
 		case 4: // Multi-Signature
-			var keysgroupBuffer = new Buffer(transaction.asset.multisignature.keysgroup.join(""), "utf8");
-			var bb = new ByteBuffer(1 + 1 + keysgroupBuffer.length, true);
+			keysgroupBuffer = new Buffer(transaction.asset.multisignature.keysgroup.join(""), "utf8");
+			bb = new ByteBuffer(1 + 1 + keysgroupBuffer.length, true);
 
 			bb.writeByte(transaction.asset.multisignature.min);
 			bb.writeByte(transaction.asset.multisignature.lifetime);
 
-			for (var i = 0; i < keysgroupBuffer.length; i++) {
+			for (let i = 0; i < keysgroupBuffer.length; i++) {
 				bb.writeByte(keysgroupBuffer[i]);
 			}
 
@@ -77,43 +78,43 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 	bb.writeByte(transaction.type);
 	bb.writeInt(transaction.timestamp);
 
-	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
-	for (i = 0; i < senderPublicKeyBuffer.length; i++) {
+	const senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
+	for (let i = 0; i < senderPublicKeyBuffer.length; i++) {
 		bb.writeByte(senderPublicKeyBuffer[i]);
 	}
 
 	if (transaction.recipientId) {
-		var recipient = bs58check.decode(transaction.recipientId);
-		for (i = 0; i < recipient.length; i++) {
+		const recipient = bs58check.decode(transaction.recipientId);
+		for (let i = 0; i < recipient.length; i++) {
 			bb.writeByte(recipient[i]);
 		}
 	} else {
-		for (i = 0; i < 21; i++) {
+		for (let i = 0; i < 21; i++) {
 			bb.writeByte(0);
 		}
 	}
 
 	if(transaction.vendorFieldHex){
-		var vf = new Buffer(transaction.vendorFieldHex,"hex");
-		var fillstart=vf.length;
-		for (i = 0; i < fillstart; i++) {
+		const vf = new Buffer(transaction.vendorFieldHex,"hex");
+		const fillstart=vf.length;
+		for (let i = 0; i < fillstart; i++) {
 			bb.writeByte(vf[i]);
 		}
-		for (i = fillstart; i < 64; i++) {
+		for (let i = fillstart; i < 64; i++) {
 			bb.writeByte(0);
 		}
 	}
 	else if (transaction.vendorField) {
-		vf = new Buffer(transaction.vendorField);
-		fillstart=vf.length;
-		for (i = 0; i < fillstart; i++) {
+		const vf = new Buffer(transaction.vendorField);
+		const fillstart=vf.length;
+		for (let i = 0; i < fillstart; i++) {
 			bb.writeByte(vf[i]);
 		}
-		for (i = fillstart; i < 64; i++) {
+		for (let i = fillstart; i < 64; i++) {
 			bb.writeByte(0);
 		}
 	} else {
-		for (i = 0; i < 64; i++) {
+		for (let i = 0; i < 64; i++) {
 			bb.writeByte(0);
 		}
 	}
@@ -123,30 +124,30 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 	bb.writeLong(transaction.fee);
 
 	if (assetSize > 0) {
-		for (i = 0; i < assetSize; i++) {
+		for (let i = 0; i < assetSize; i++) {
 			bb.writeByte(assetBytes[i]);
 		}
 	}
 
 	if (!skipSignature && transaction.signature) {
-		var signatureBuffer = new Buffer(transaction.signature, "hex");
-		for (i = 0; i < signatureBuffer.length; i++) {
+		const signatureBuffer = new Buffer(transaction.signature, "hex");
+		for (let i = 0; i < signatureBuffer.length; i++) {
 			bb.writeByte(signatureBuffer[i]);
 		}
 	}
 
 	if (!skipSecondSignature && transaction.signSignature) {
-		var signSignatureBuffer = new Buffer(transaction.signSignature, "hex");
-		for (i = 0; i < signSignatureBuffer.length; i++) {
+		const signSignatureBuffer = new Buffer(transaction.signSignature, "hex");
+		for (let i = 0; i < signSignatureBuffer.length; i++) {
 			bb.writeByte(signSignatureBuffer[i]);
 		}
 	}
 
 	bb.flip();
-	var arrayBuffer = new Uint8Array(bb.toArrayBuffer()); // eslint-disable-line no-undef
-	var buffer = [];
+	const arrayBuffer = new Uint8Array(bb.toArrayBuffer()); // eslint-disable-line no-undef
+	const buffer = [];
 
-	for (i = 0; i < arrayBuffer.length; i++) {
+	for (let i = 0; i < arrayBuffer.length; i++) {
 		buffer[i] = arrayBuffer[i];
 	}
 
@@ -154,8 +155,8 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 }
 
 function fromBytes(hexString){
-	var tx={};
-	var buf = new Buffer(hexString, "hex");
+	const tx={};
+	const buf = new Buffer(hexString, "hex");
 	tx.type = buf.readInt8(0) & 0xff;
 	tx.timestamp = buf.readUInt32LE(1);
 	tx.senderPublicKey = hexString.substring(10,10+33*2);
@@ -178,7 +179,7 @@ function fromBytes(hexString){
 	else if(tx.type == 2){ // delegate registration
 		delete tx.recipientId;
 		// Impossible to assess size of delegate asset, trying to grab signature and derive delegate asset
-		offset = findAndParseSignatures(hexString, tx);
+		const offset = findAndParseSignatures(hexString, tx);
 
 		tx.asset = {
 			delegate: {
@@ -188,24 +189,24 @@ function fromBytes(hexString){
 	}
 	else if(tx.type == 3){ // vote
 		// Impossible to assess size of vote asset, trying to grab signature and derive vote asset
-		var offset = findAndParseSignatures(hexString, tx);
+		const offset = findAndParseSignatures(hexString, tx);
 		tx.asset = {
 			votes: new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex").toString("utf8").split(",")
 		};
 	}
 	else if(tx.type == 4){ // multisignature creation
 		delete tx.recipientId;
-		offset = findAndParseSignatures(hexString, tx);
-		var buffer = new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex")
+		const offset = findAndParseSignatures(hexString, tx);
+		const buffer = new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex")
 		tx.asset = {
 			multisignature: {}
 		}
 		tx.asset.multisignature.min = buffer.readInt8(0) & 0xff;
 		tx.asset.multisignature.lifetime = buffer.readInt8(1) & 0xff;
 		tx.asset.multisignature.keysgroup = [];
-		var index = 0;
+		let index = 0;
 		while(index + 2 < buffer.length){
-			var key = buffer.slice(index+2,index+66+2).toString("utf8");
+			const key = buffer.slice(index+2,index+66+2).toString("utf8");
 			tx.asset.multisignature.keysgroup.push(key);
 			index = index + 66;
 		}
@@ -218,10 +219,10 @@ function fromBytes(hexString){
 }
 
 function findAndParseSignatures(hexString, tx){
-	var signature1 = new Buffer(hexString.substring(hexString.length-146), "hex");
-	var signature2 = null;
-	var found      = false;
-	var offset     = 0;
+	let signature1 = new Buffer(hexString.substring(hexString.length-146), "hex");
+	let signature2 = null;
+	let found      = false;
+	let offset     = 0;
 	while(!found && signature1.length > 8){
 		if(signature1[0] != 0x30){
 			signature1 = signature1.slice(1);
@@ -270,7 +271,7 @@ function parseSignatures(hexString, tx, startOffset){
 	tx.signature = hexString.substring(startOffset);
 	if(tx.signature.length == 0) delete tx.signature;
 	else {
-		var length = parseInt("0x" + tx.signature.substring(2,4), 16) + 2;
+		const length = parseInt("0x" + tx.signature.substring(2,4), 16) + 2;
 		tx.signature = hexString.substring(startOffset, startOffset + length*2);
 		tx.signSignature = hexString.substring(startOffset + length*2);
 		if(tx.signSignature.length == 0) delete tx.signSignature;
@@ -302,9 +303,9 @@ function getFee(transaction) {
 }
 
 function sign(transaction, keys) {
-	var hash = getHash(transaction, true, true);
+	const hash = getHash(transaction, true, true);
 
-	var signature = keys.sign(hash).toDER().toString("hex");
+	const signature = keys.sign(hash).toDER().toString("hex");
 
 	if (!transaction.signature) {
 		transaction.signature = signature;
@@ -314,9 +315,9 @@ function sign(transaction, keys) {
 }
 
 function secondSign(transaction, keys) {
-	var hash = getHash(transaction, false, true);
+	const hash = getHash(transaction, false, true);
 
-	var signature = keys.sign(hash).toDER().toString("hex");
+	const signature = keys.sign(hash).toDER().toString("hex");
 
 	if (!transaction.signSignature) {
 		transaction.signSignature = signature;
@@ -327,13 +328,13 @@ function secondSign(transaction, keys) {
 function verify(transaction, network) {
 	network = network || networks.ark;
 
-	var hash = getHash(transaction, true, true);
+	const hash = getHash(transaction, true, true);
 
-	var signatureBuffer = new Buffer(transaction.signature, "hex");
-	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
-	var ecpair = ECPair.fromPublicKeyBuffer(senderPublicKeyBuffer, network);
-	var ecsignature = ECSignature.fromDER(signatureBuffer);
-	var res = ecpair.verify(hash, ecsignature);
+	const signatureBuffer = new Buffer(transaction.signature, "hex");
+	const senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
+	const ecpair = ECPair.fromPublicKeyBuffer(senderPublicKeyBuffer, network);
+	const ecsignature = ECSignature.fromDER(signatureBuffer);
+	const res = ecpair.verify(hash, ecsignature);
 
 	return res;
 }
@@ -341,19 +342,19 @@ function verify(transaction, network) {
 function verifySecondSignature(transaction, publicKey, network) {
 	network = network || networks.ark;
 
-	var hash = getHash(transaction, false, true);
+	const hash = getHash(transaction, false, true);
 
-	var signSignatureBuffer = new Buffer(transaction.signSignature, "hex");
-	var publicKeyBuffer = new Buffer(publicKey, "hex");
-	var ecpair = ECPair.fromPublicKeyBuffer(publicKeyBuffer, network);
-	var ecsignature = ECSignature.fromDER(signSignatureBuffer);
-	var res = ecpair.verify(hash, ecsignature);
+	const signSignatureBuffer = new Buffer(transaction.signSignature, "hex");
+	const publicKeyBuffer = new Buffer(publicKey, "hex");
+	const ecpair = ECPair.fromPublicKeyBuffer(publicKeyBuffer, network);
+	const ecsignature = ECSignature.fromDER(signSignatureBuffer);
+	const res = ecpair.verify(hash, ecsignature);
 
 	return res;
 }
 
 function getKeys(secret, network) {
-	var ecpair = ECPair.fromSeed(secret, network || networks.ark);
+	const ecpair = ECPair.fromSeed(secret, network || networks.ark);
 
 	ecpair.publicKey = ecpair.getPublicKeyBuffer().toString("hex");
 	ecpair.privateKey = '';
@@ -365,9 +366,9 @@ function getAddress(publicKey, version){
 	if(!version){
 		version = networkVersion;
 	}
-	var buffer = crypto_utils.ripemd160(new Buffer(publicKey,'hex'));
+	const buffer = crypto_utils.ripemd160(new Buffer(publicKey,'hex'));
 
-	var payload = new Buffer(21);
+	const payload = new Buffer(21);
 	payload.writeUInt8(version, 0);
 	buffer.copy(payload, 1);
 
@@ -387,7 +388,7 @@ function validateAddress(address, version){
 		version = networkVersion;
 	}
 	try {
-		var decode = bs58check.decode(address);
+		const decode = bs58check.decode(address);
 		return decode[0] == version;
 	} catch(e){
 		return false;

--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -214,7 +214,6 @@ function fromBytes(hexString){
 		delete tx.recipientId;
 		parseSignatures(hexString, tx, 76+42+128+32);
 	}
-	//console.log(tx);
 	return tx;
 }
 

--- a/lib/transactions/delegate.js
+++ b/lib/transactions/delegate.js
@@ -1,11 +1,11 @@
-var crypto = require("./crypto.js"),
-    constants = require("../constants.js"),
-    slots = require("../time/slots.js");
+const crypto = require("./crypto.js")
+const constants = require("../constants.js")
+const slots = require("../time/slots.js")
 
 function createDelegate(secret, username, secondSecret) {
 	if (!secret || !username) return false;
 
-	var keys = secret;
+	let keys = secret;
 
 	if (!crypto.isECPair(secret)) {
 		keys = crypto.getKeys(secret);
@@ -15,7 +15,7 @@ function createDelegate(secret, username, secondSecret) {
 		throw new Error("Invalid public key");
 	}
 
-	var transaction = {
+	const transaction = {
 		type: 2,
 		amount: 0,
 		fee: constants.fees.delegate,
@@ -33,7 +33,7 @@ function createDelegate(secret, username, secondSecret) {
 	crypto.sign(transaction, keys);
 
 	if (secondSecret) {
-		var secondKeys = secondSecret;
+		let secondKeys = secondSecret;
 		if (!crypto.isECPair(secondSecret)) {
 			secondKeys = crypto.getKeys(secondSecret);
 		}

--- a/lib/transactions/ipfs.js
+++ b/lib/transactions/ipfs.js
@@ -12,7 +12,7 @@ function createHashRegistration(ipfshash, secret, secondSecret) {
 	};
 
   transaction.vendorFieldHex = new Buffer(ipfshash,"utf8").toString("hex");
-  //filling with 0x00
+  // filling with 0x00
   while(transaction.vendorFieldHex.length < 128){
     transaction.vendorFieldHex = "00"+transaction.vendorFieldHex;
   }

--- a/lib/transactions/ipfs.js
+++ b/lib/transactions/ipfs.js
@@ -1,11 +1,11 @@
-var crypto = require("./crypto.js"),
-    constants = require("../constants.js"),
-    slots = require("../time/slots.js");
+const crypto = require("./crypto.js")
+const constants = require("../constants.js")
+const slots = require("../time/slots.js")
 
 function createHashRegistration(ipfshash, secret, secondSecret) {
 	if (!ipfshash || !secret) return false;
 
-	var transaction = {
+	const transaction = {
 		type: 5,
     amount:0,
 		fee: constants.fees.send,
@@ -19,7 +19,7 @@ function createHashRegistration(ipfshash, secret, secondSecret) {
     transaction.vendorFieldHex = "00"+transaction.vendorFieldHex;
 	}
 
-	var keys = secret;
+	let keys = secret;
 
 	if (!crypto.isECPair(secret)) {
 		keys = crypto.getKeys(secret);
@@ -34,7 +34,7 @@ function createHashRegistration(ipfshash, secret, secondSecret) {
 	crypto.sign(transaction, keys);
 
 	if (secondSecret) {
-		var secondKeys = secondSecret;
+		let secondKeys = secondSecret;
 		if (!crypto.isECPair(secondSecret)) {
 			secondKeys = crypto.getKeys(secondSecret);
 		}

--- a/lib/transactions/multisignature.js
+++ b/lib/transactions/multisignature.js
@@ -1,17 +1,17 @@
-var crypto = require("./crypto.js"),
-    constants = require("../constants.js"),
-    slots = require("../time/slots.js");
+const crypto = require("./crypto.js")
+const constants = require("../constants.js")
+const slots = require("../time/slots.js")
 
 function signTransaction(trs, secret) {
 	if (!trs || !secret) return false;
 
-	var keys = secret;
+	let keys = secret;
 
 	if (!crypto.isECPair(secret)) {
 		keys = crypto.getKeys(secret);
 	}
 
-	var signature = crypto.sign(trs, keys);
+	const signature = crypto.sign(trs, keys);
 
 	return signature;
 }
@@ -19,13 +19,13 @@ function signTransaction(trs, secret) {
 function createMultisignature(secret, secondSecret, keysgroup, lifetime, min) {
 	if (!secret || !keysgroup || !lifetime || !min) return false;
 
-	var keys = secret;
+	let keys = secret;
 
 	if (!crypto.isECPair(secret)) {
 		keys = crypto.getKeys(secret);
 	}
 
-	var transaction = {
+	const transaction = {
 		type: 4,
 		amount: 0,
 		fee: constants.fees.multisignature,
@@ -44,7 +44,7 @@ function createMultisignature(secret, secondSecret, keysgroup, lifetime, min) {
 	crypto.sign(transaction, keys);
 
 	if (secondSecret) {
-		var secondKeys = secondSecret;
+		let secondKeys = secondSecret;
 		if (!crypto.isECPair(secondSecret)) {
 			secondKeys = crypto.getKeys(secondSecret);
 		}

--- a/lib/transactions/signature.js
+++ b/lib/transactions/signature.js
@@ -1,11 +1,11 @@
-var crypto = require("./crypto.js"),
-    constants = require("../constants.js"),
-    slots = require("../time/slots.js");
+const crypto = require("./crypto.js")
+const constants = require("../constants.js")
+const slots = require("../time/slots.js");
 
 function newSignature(secondSecret) {
-	var keys = crypto.getKeys(secondSecret);
+	const keys = crypto.getKeys(secondSecret);
 
-	var signature = {
+	const signature = {
 		publicKey: keys.publicKey
 	};
 
@@ -15,7 +15,7 @@ function newSignature(secondSecret) {
 function createSignature(secret, secondSecret) {
 	if (!secret || !secondSecret) return false;
 
-	var keys = secret;
+	let keys = secret;
 
 	if (!crypto.isECPair(secret)) {
 		keys = crypto.getKeys(secret);
@@ -25,8 +25,8 @@ function createSignature(secret, secondSecret) {
     throw new Error("Invalid public key");
   }
 
-	var signature = newSignature(secondSecret);
-	var transaction = {
+	const signature = newSignature(secondSecret);
+	const transaction = {
 		type: 1,
 		amount: 0,
 		fee: constants.fees.secondsignature,

--- a/lib/transactions/transaction.js
+++ b/lib/transactions/transaction.js
@@ -1,6 +1,6 @@
-var crypto = require("./crypto.js"),
-    constants = require("../constants.js"),
-    slots = require("../time/slots.js");
+const crypto = require("./crypto.js")
+const constants = require("../constants.js")
+const slots = require("../time/slots.js")
 
 function createTransaction(recipientId, amount, vendorField, secret, secondSecret) {
 	if (!recipientId || !amount || !secret) return false;
@@ -9,7 +9,7 @@ function createTransaction(recipientId, amount, vendorField, secret, secondSecre
     throw new Error("Wrong recipientId");
 	}
 
-	var keys = secret;
+	let keys = secret;
 
 	if (!crypto.isECPair(secret)) {
 		keys = crypto.getKeys(secret);
@@ -19,7 +19,7 @@ function createTransaction(recipientId, amount, vendorField, secret, secondSecre
     throw new Error("Invalid public key");
   }
 
-	var transaction = {
+	const transaction = {
 		type: 0,
 		amount: amount,
 		fee: constants.fees.send,
@@ -40,7 +40,7 @@ function createTransaction(recipientId, amount, vendorField, secret, secondSecre
 	crypto.sign(transaction, keys);
 
 	if (secondSecret) {
-		var secondKeys = secondSecret;
+		let secondKeys = secondSecret;
 		if (!crypto.isECPair(secondSecret)) {
 			secondKeys = crypto.getKeys(secondSecret);
 		}

--- a/lib/transactions/vote.js
+++ b/lib/transactions/vote.js
@@ -1,11 +1,11 @@
-var crypto = require("./crypto.js"),
-    constants = require("../constants.js"),
-    slots = require("../time/slots.js");
+const crypto = require("./crypto.js")
+const constants = require("../constants.js")
+const slots = require("../time/slots.js")
 
 function createVote(secret, delegates, secondSecret) {
 	if (!secret || !Array.isArray(delegates)) return;
 
-	var keys = secret;
+	let keys = secret;
 
 	if (!crypto.isECPair(secret)) {
 		keys = crypto.getKeys(secret);
@@ -15,7 +15,7 @@ function createVote(secret, delegates, secondSecret) {
     throw new Error("Invalid public key");
   }
 
-	var transaction = {
+	const transaction = {
 		type: 3,
 		amount: 0,
 		fee: constants.fees.vote,
@@ -30,7 +30,7 @@ function createVote(secret, delegates, secondSecret) {
 	crypto.sign(transaction, keys);
 
 	if (secondSecret) {
-		var secondKeys = secondSecret;
+		let secondKeys = secondSecret;
 		if (!crypto.isECPair(secondSecret)) {
 			secondKeys = crypto.getKeys(secondSecret);
 		}

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,6 +1,6 @@
-var typeforce = require('typeforce')
+const typeforce = require('typeforce')
 
-var UINT31_MAX = Math.pow(2, 31) - 1
+const UINT31_MAX = Math.pow(2, 31) - 1
 function UInt31 (value) {
   return typeforce.UInt32(value) && value <= UINT31_MAX
 }
@@ -10,18 +10,18 @@ function BIP32Path (value) {
 }
 BIP32Path.toJSON = function () { return 'BIP32 derivation path' }
 
-var SATOSHI_MAX = 21 * 1e14
+const SATOSHI_MAX = 21 * 1e14
 function Satoshi (value) {
   return typeforce.UInt53(value) && value <= SATOSHI_MAX
 }
 
 // external dependent types
-var BigInt = typeforce.quacksLike('BigInteger')
-var ECPoint = typeforce.quacksLike('Point')
+const BigInt = typeforce.quacksLike('BigInteger')
+const ECPoint = typeforce.quacksLike('Point')
 
 // exposed, external API
-var ECSignature = typeforce.compile({ r: BigInt, s: BigInt })
-var Network = typeforce.compile({
+const ECSignature = typeforce.compile({ r: BigInt, s: BigInt })
+const Network = typeforce.compile({
   messagePrefix: typeforce.oneOf(typeforce.Buffer, typeforce.String),
   bip32: {
     public: typeforce.UInt32,
@@ -32,7 +32,7 @@ var Network = typeforce.compile({
 })
 
 // extend typeforce types with ours
-var types = {
+const types = {
   BigInt: BigInt,
   BIP32Path: BIP32Path,
   Buffer256bit: typeforce.BufferN(32),
@@ -45,7 +45,7 @@ var types = {
   UInt31: UInt31
 }
 
-for (var typeName in typeforce) {
+for (const typeName in typeforce) {
   types[typeName] = typeforce[typeName]
 }
 

--- a/lib/v2/transactions/crypto.js
+++ b/lib/v2/transactions/crypto.js
@@ -1,25 +1,25 @@
-var crypto = require("crypto");
-var crypto_utils = require("../../crypto.js");
-var ECPair = require("../../ecpair.js");
-var ECSignature = require("../../ecsignature.js");
-var networks = require("../../networks.js")
+const crypto = require("crypto");
+const crypto_utils = require("../../crypto.js");
+const ECPair = require("../../ecpair.js");
+const ECSignature = require("../../ecsignature.js");
+const networks = require("../../networks.js")
 
-var bs58check = require('bs58check')
+const bs58check = require('bs58check')
 
 if (typeof Buffer === "undefined") {
 	Buffer = require("buffer/").Buffer; // eslint-disable-line no-global-assign
 }
 
-var ByteBuffer = require("bytebuffer");
+const ByteBuffer = require("bytebuffer");
 
 
-var fixedPoint = Math.pow(10, 8);
+const fixedPoint = Math.pow(10, 8);
 // default is ark mainnet
-var networkVersion = 0x17;
+let networkVersion = 0x17;
 
 
 function getBytes(transaction) {
-	var bb = new ByteBuffer(512, true);
+	const bb = new ByteBuffer(512, true);
 	bb.writeByte(0xff); // fill, to disambiguate from v1
 	bb.writeByte(transaction.version); // version 2
 	bb.writeByte(transaction.network); // ark = 0x17, devnet = 0x30
@@ -35,6 +35,7 @@ function getBytes(transaction) {
 		bb.writeByte(0x00);
 	}
 
+	let delegateBytes, keysgroupBuffer, voteBytes
 	switch (transaction.type) {
 		case 0: // Transfer
 			bb.writeLong(transaction.amount);
@@ -47,13 +48,13 @@ function getBytes(transaction) {
 			break;
 
 		case 2: // Delegate
-			var delegateBytes = new Buffer(transaction.asset.delegate.username, "utf8");
+			delegateBytes = new Buffer(transaction.asset.delegate.username, "utf8");
 			bb.writeByte(delegateBytes.length/2);
 			bb.append(delegateBytes,"hex");
 			break;
 
 		case 3: // Vote
-			var voteBytes = transaction.asset.votes.map(function(vote){
+			voteBytes = transaction.asset.votes.map(function(vote){
 				return (vote[0] == "+" ? "01" : "00") + vote.slice(1);
 			}).join("");
 			bb.writeByte(transaction.asset.votes.length);
@@ -61,7 +62,7 @@ function getBytes(transaction) {
 			break;
 
 		case 4: // Multi-Signature
-			var keysgroupBuffer = new Buffer(transaction.asset.multisignature.keysgroup.join(""), "hex");
+			keysgroupBuffer = new Buffer(transaction.asset.multisignature.keysgroup.join(""), "hex");
 			bb.writeByte(transaction.asset.multisignature.min);
 			bb.writeByte(transaction.asset.multisignature.keysgroup.length);
 			bb.writeByte(transaction.asset.multisignature.lifetime);
@@ -96,20 +97,22 @@ function getBytes(transaction) {
 }
 
 function fromBytes(hexString){
-	var tx={};
-	var buf = new Buffer(hexString, "hex");
+	const tx={};
+	const buf = new Buffer(hexString, "hex");
 	tx.version = buf.readInt8(1) & 0xff;
 	tx.network = buf.readInt8(2) & 0xff;
 	tx.type = buf.readInt8(3) & 0xff;
 	tx.timestamp = buf.readUInt32LE(4);
 	tx.senderPublicKey = hexString.substring(16,16+33*2);
 	tx.fee = buf.readUInt32LE(41);
-	var vflength = buf.readInt8(41+8) & 0xff;
+	const vflength = buf.readInt8(41+8) & 0xff;
 	if(vflength > 0){
 		tx.vendorFieldHex=hexString.substring((41+8+1)*2,(41+8+1)*2+vflength*2);
 	}
 
-	var assetOffset = (41+8+1)*2+vflength*2;
+	const assetOffset = (41+8+1)*2+vflength*2;
+	let offset = assetOffset/2 + 1;
+	let buffer
 
 	if(tx.type == 0){ // transfer
 		tx.amount = buf.readUInt32LE(assetOffset/2);
@@ -126,7 +129,7 @@ function fromBytes(hexString){
 		parseSignatures(hexString, tx, assetOffset+66);
 	}
 	else if(tx.type == 2){ // delegate registration
-		var usernamelength = buf.readInt8(assetOffset/2) & 0xff;
+		const usernamelength = buf.readInt8(assetOffset/2) & 0xff;
 
 		tx.asset = {
 			delegate: {
@@ -136,10 +139,10 @@ function fromBytes(hexString){
 		parseSignatures(hexString, tx, assetOffset + (usernamelength+1)*2);
 	}
 	else if(tx.type == 3){ // vote
-		var votelength = buf.readInt8(assetOffset/2) & 0xff;
+		const votelength = buf.readInt8(assetOffset/2) & 0xff;
 		tx.asset = {votes:[]};
-		var vote;
-		for(var i = 0; i<votelength; i++){
+		let vote;
+		for(let i = 0; i<votelength; i++){
 			vote = hexString.substring(assetOffset + 2 + i*2*34, assetOffset + 2 + (i+1)*2*34);
 			vote = (vote[1] == "1" ? "+" : "-") + vote.slice(2);
 			tx.asset.votes.push(vote);
@@ -147,22 +150,22 @@ function fromBytes(hexString){
 		parseSignatures(hexString, tx, assetOffset + 2 + votelength*34*2);
 	}
 	else if(tx.type == 4){ // multisignature creation
-		var buffer = new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex")
+		buffer = new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex")
 		tx.asset = {
 			multisignature: {}
 		}
 		tx.asset.multisignature.min = buffer.readInt8(assetOffset/2) & 0xff;
-		var num = buffer.readInt8(assetOffset/2+1) & 0xff;
+		const num = buffer.readInt8(assetOffset/2+1) & 0xff;
 		tx.asset.multisignature.lifetime = buffer.readInt8(assetOffset/2+2) & 0xff;
 		tx.asset.multisignature.keysgroup = [];
-		for(var index = 0; index < num; index++){
+		for(let index = 0; index < num; index++){
 			/*var key = */hexString.slice(assetOffset + 6 + index*66, assetOffset + 6 + (index+1)*66);
 		}
 		parseSignatures(hexString, tx, assetOffset + 6 + num*66);
 	}
 	else if(tx.type == 5){ // ipfs
 		tx.asset = {};
-		var l = buf.readInt8(assetOffset/2) & 0xff;
+		const l = buf.readInt8(assetOffset/2) & 0xff;
 		tx.asset.dag = hexString.substring(assetOffset+2,assetOffset+2+l*2);
 		parseSignatures(hexString, tx, assetOffset+2+l*2);
 	}
@@ -177,10 +180,9 @@ function fromBytes(hexString){
 		tx.asset = {
 			payments: []
 		}
-		var total = buffer.readInt8(assetOffset/2) & 0xff;
-		var offset = assetOffset/2 + 1;
-		for(i = 0; i<total; i++){
-			var payment = {};
+		const total = buffer.readInt8(assetOffset/2) & 0xff;
+		for(let i = 0; i<total; i++){
+			const payment = {};
 			payment.amount = buf.readUInt32LE(offset);
 			payment.recipientId = bs58check.encode(buf.slice(offset+1,offset+1+21));
 			tx.asset.payments.push(payment);
@@ -198,7 +200,7 @@ function parseSignatures(hexString, tx, startOffset){
 	tx.signature = hexString.substring(startOffset);
 	if(tx.signature.length == 0) delete tx.signature;
 	else {
-		var length = parseInt("0x" + tx.signature.substring(2,4), 16) + 2;
+		const length = parseInt("0x" + tx.signature.substring(2,4), 16) + 2;
 		tx.signature = hexString.substring(startOffset, startOffset + length*2);
 		tx.secondSignature = hexString.substring(startOffset + length*2);
 		if(tx.secondSignature.length == 0) delete tx.secondSignature;
@@ -230,9 +232,9 @@ function getFee(transaction) {
 }
 
 function sign(transaction, keys) {
-	var hash = getHash(transaction);
+	const hash = getHash(transaction);
 
-	var signature = keys.sign(hash).toDER().toString("hex");
+	const signature = keys.sign(hash).toDER().toString("hex");
 
 	if (!transaction.signature) {
 		transaction.signature = signature;
@@ -241,9 +243,9 @@ function sign(transaction, keys) {
 }
 
 function secondSign(transaction, keys) {
-	var hash = getHash(transaction);
+	const hash = getHash(transaction);
 
-	var signature = keys.sign(hash).toDER().toString("hex");
+	const signature = keys.sign(hash).toDER().toString("hex");
 
 	if (!transaction.secondSignature) {
 		transaction.secondSignature = signature;
@@ -254,13 +256,13 @@ function secondSign(transaction, keys) {
 function verify(transaction, network) {
 	network = network || networks.ark;
 
-	var hash = getHash(transaction);
+	const hash = getHash(transaction);
 
-	var signatureBuffer = new Buffer(transaction.signature, "hex");
-	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
-	var ecpair = ECPair.fromPublicKeyBuffer(senderPublicKeyBuffer, network);
-	var ecsignature = ECSignature.fromDER(signatureBuffer);
-	var res = ecpair.verify(hash, ecsignature);
+	const signatureBuffer = new Buffer(transaction.signature, "hex");
+	const senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
+	const ecpair = ECPair.fromPublicKeyBuffer(senderPublicKeyBuffer, network);
+	const ecsignature = ECSignature.fromDER(signatureBuffer);
+	const res = ecpair.verify(hash, ecsignature);
 
 	return res;
 }
@@ -268,19 +270,19 @@ function verify(transaction, network) {
 function verifySecondSignature(transaction, publicKey, network) {
 	network = network || networks.ark;
 
-	var hash = getHash(transaction);
+	const hash = getHash(transaction);
 
-	var secondSignatureBuffer = new Buffer(transaction.secondSignature, "hex");
-	var publicKeyBuffer = new Buffer(publicKey, "hex");
-	var ecpair = ECPair.fromPublicKeyBuffer(publicKeyBuffer, network);
-	var ecsignature = ECSignature.fromDER(secondSignatureBuffer);
-	var res = ecpair.verify(hash, ecsignature);
+	const secondSignatureBuffer = new Buffer(transaction.secondSignature, "hex");
+	const publicKeyBuffer = new Buffer(publicKey, "hex");
+	const ecpair = ECPair.fromPublicKeyBuffer(publicKeyBuffer, network);
+	const ecsignature = ECSignature.fromDER(secondSignatureBuffer);
+	const res = ecpair.verify(hash, ecsignature);
 
 	return res;
 }
 
 function getKeys(secret, network) {
-	var ecpair = ECPair.fromSeed(secret, network || networks.ark);
+	const ecpair = ECPair.fromSeed(secret, network || networks.ark);
 	ecpair.publicKey = ecpair.getPublicKeyBuffer().toString("hex");
 	ecpair.privateKey = '';
 
@@ -291,9 +293,9 @@ function getAddress(publicKey, version){
 	if(!version){
 		version = networkVersion;
 	}
-	var buffer = crypto_utils.ripemd160(new Buffer(publicKey,'hex'));
+	const buffer = crypto_utils.ripemd160(new Buffer(publicKey,'hex'));
 
-	var payload = new Buffer(21);
+	const payload = new Buffer(21);
 	payload.writeUInt8(version, 0);
 	buffer.copy(payload, 1);
 
@@ -313,7 +315,7 @@ function validateAddress(address, version){
 		version = networkVersion;
 	}
 	try {
-		var decode = bs58check.decode(address);
+		const decode = bs58check.decode(address);
 		return decode[0] == version;
 	} catch(e){
 		return false;

--- a/lib/v2/transactions/crypto.js
+++ b/lib/v2/transactions/crypto.js
@@ -7,7 +7,7 @@ var networks = require("../../networks.js")
 var bs58check = require('bs58check')
 
 if (typeof Buffer === "undefined") {
-	Buffer = require("buffer/").Buffer;
+	Buffer = require("buffer/").Buffer; // eslint-disable-line no-global-assign
 }
 
 var ByteBuffer = require("bytebuffer");
@@ -20,7 +20,7 @@ var networkVersion = 0x17;
 
 function getBytes(transaction) {
 	var bb = new ByteBuffer(512, true);
-	bb.writeByte(0xff); // fill, to disambiguate from v1 
+	bb.writeByte(0xff); // fill, to disambiguate from v1
 	bb.writeByte(transaction.version); // version 2
 	bb.writeByte(transaction.network); // ark = 0x17, devnet = 0x30
 	bb.writeByte(transaction.type);
@@ -72,8 +72,8 @@ function getBytes(transaction) {
 			bb.writeByte(transaction.asset.ipfs.dag.length/2);
 			bb.append(transaction.asset.ipfs.dag,"hex");
 			break;
-		
-		case 6: // timelock transfer 
+
+		case 6: // timelock transfer
 			bb.writeLong(transaction.amount);
 			bb.writeByte(transaction.timelocktype);
 			bb.writeInt(transaction.timelock);
@@ -110,7 +110,7 @@ function fromBytes(hexString){
 	}
 
 	var assetOffset = (41+8+1)*2+vflength*2;
-    
+
 	if(tx.type == 0){ // transfer
 		tx.amount = buf.readUInt32LE(assetOffset/2);
 		tx.expiration = buf.readUInt32LE(assetOffset/2+8);
@@ -147,6 +147,7 @@ function fromBytes(hexString){
 		parseSignatures(hexString, tx, assetOffset + 2 + votelength*34*2);
 	}
 	else if(tx.type == 4){ // multisignature creation
+		var buffer = new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex")
 		tx.asset = {
 			multisignature: {}
 		}
@@ -155,7 +156,7 @@ function fromBytes(hexString){
 		tx.asset.multisignature.lifetime = buffer.readInt8(assetOffset/2+2) & 0xff;
 		tx.asset.multisignature.keysgroup = [];
 		for(var index = 0; index < num; index++){
-			var key = hexString.slice(assetOffset + 6 + index*66, assetOffset + 6 + (index+1)*66);
+			/*var key = */hexString.slice(assetOffset + 6 + index*66, assetOffset + 6 + (index+1)*66);
 		}
 		parseSignatures(hexString, tx, assetOffset + 6 + num*66);
 	}
@@ -178,7 +179,7 @@ function fromBytes(hexString){
 		}
 		var total = buffer.readInt8(assetOffset/2) & 0xff;
 		var offset = assetOffset/2 + 1;
-		for(var i = 0; i<total; i++){
+		for(i = 0; i<total; i++){
 			var payment = {};
 			payment.amount = buf.readUInt32LE(offset);
 			payment.recipientId = bs58check.encode(buf.slice(offset+1,offset+1+21));
@@ -216,19 +217,15 @@ function getFee(transaction) {
 	switch (transaction.type) {
 		case 0: // Normal
 			return 0.1 * fixedPoint;
-			break;
 
 		case 1: // Signature
 			return 100 * fixedPoint;
-			break;
 
 		case 2: // Delegate
 			return 10000 * fixedPoint;
-			break;
 
 		case 3: // Vote
 			return 1 * fixedPoint;
-			break;
 	}
 }
 

--- a/lib/v2/transactions/transfer.js
+++ b/lib/v2/transactions/transfer.js
@@ -1,6 +1,6 @@
-var crypto = require("./crypto.js"),
-    constants = require("../../constants.js"),
-		slots = require("../../time/slots.js");
+const crypto = require("./crypto.js")
+const constants = require("../../constants.js")
+const	slots = require("../../time/slots.js")
 
 function Transfer(){
 	this.id = null;
@@ -30,7 +30,7 @@ Transfer.prototype.setVendorField = function(data, type){
 }
 
 Transfer.prototype.sign = function(passphrase){
-	var keys = crypto.getKeys(passphrase);
+	const keys = crypto.getKeys(passphrase);
 	this.senderPublicKey = keys.publicKey;
 	this.signature = crypto.sign(this, keys);
 	return this;
@@ -41,7 +41,7 @@ Transfer.prototype.verify = function(){
 }
 
 Transfer.prototype.secondSign = function(passphrase, transaction){
-	var keys = crypto.getKeys(passphrase);
+	const keys = crypto.getKeys(passphrase);
 	this.secondSignature = crypto.secondSign(transaction, keys);
 	return this;
 }

--- a/lib/v2/transactions/transfer.js
+++ b/lib/v2/transactions/transfer.js
@@ -1,7 +1,7 @@
 var crypto = require("./crypto.js"),
     constants = require("../../constants.js"),
 		slots = require("../../time/slots.js");
-		
+
 function Transfer(){
 	this.id = null;
 	this.amount = 0;
@@ -40,7 +40,7 @@ Transfer.prototype.verify = function(){
 	return crypto.verify(this);
 }
 
-Transfer.prototype.secondSign = function(passphrase){
+Transfer.prototype.secondSign = function(passphrase, transaction){
 	var keys = crypto.getKeys(passphrase);
 	this.secondSignature = crypto.secondSign(transaction, keys);
 	return this;

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typeforce": "^1.10.3",
     "wif": "^2.0.4"
   },
-  "devDependencies": {,
+  "devDependencies": {
     "eslint": "^4.2.0",
     "mocha": "=3.1.0",
     "proxyquire": "^1.7.10",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:docs": "jsdoc -c jsdoc.json",
     "clean": "shx rm -r ./docs",
     "lint": "eslint .",
-    "test": "mocha test/ark.js test/*/*"
+    "test": "mocha --use_strict test/ark.js test/*/*"
   },
   "directories": {
     "lib": "./lib",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "wif": "^2.0.4"
   },
   "devDependencies": {
-    "eslint": "^4.2.0",
+    "eslint": "^4.4.1",
     "proxyquire": "^1.7.10",
     "should": "=11.1.0",
     "sinon": "^1.17.7"

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,6 @@
+{
+    "extends": "../.eslintrc",
+    "env": {
+        "mocha": true
+    }
+}

--- a/test/ark.js
+++ b/test/ark.js
@@ -1,5 +1,4 @@
-var Buffer = require("buffer/").Buffer;
-var should = require("should");
+require("should");
 var ark = require("../index.js");
 
 describe("Ark JS", function () {

--- a/test/ark.js
+++ b/test/ark.js
@@ -1,5 +1,5 @@
 require("should");
-var ark = require("../index.js");
+const ark = require("../index.js");
 
 describe("Ark JS", function () {
 
@@ -12,7 +12,7 @@ describe("Ark JS", function () {
 	});
 
 	it("should have properties", function () {
-		var properties = ["transaction", "signature", "vote", "delegate", "crypto"];
+		const properties = ["transaction", "signature", "vote", "delegate", "crypto"];
 
 		properties.forEach(function (property) {
 			(ark).should.have.property(property);

--- a/test/crypto/index.js
+++ b/test/crypto/index.js
@@ -1,17 +1,17 @@
 /* eslint-disable max-len */
 
 require("should");
-var Buffer = require("buffer/").Buffer;
-var ark = require("../../index.js");
-var ECPair = require('../../lib/ecpair');
+const Buffer = require("buffer/").Buffer;
+const ark = require("../../index.js");
+const ECPair = require('../../lib/ecpair');
 
-var ecdsa = require('../../lib/ecdsa')
-var ecurve = require('ecurve')
-var curve = ecdsa.__curve
+const ecdsa = require('../../lib/ecdsa')
+const ecurve = require('ecurve')
+const curve = ecdsa.__curve
 
 describe("crypto.js", function () {
 
-  var crypto = ark.crypto;
+  const crypto = ark.crypto;
 
   it("should be ok", function () {
     (crypto).should.be.ok;
@@ -22,7 +22,7 @@ describe("crypto.js", function () {
   });
 
   it("should has properties", function () {
-    var properties = [
+    const properties = [
       "getBytes", "getHash", "getId", "getFee", "sign", "secondSign",
       "getKeys", "getAddress", "verify", "verifySecondSignature", "fixedPoint"
     ];
@@ -32,8 +32,8 @@ describe("crypto.js", function () {
   });
 
   describe("#getBytes", function () {
-    var getBytes = crypto.getBytes;
-    var bytes = null;
+    const getBytes = crypto.getBytes;
+    let bytes = null;
 
     it("should be ok", function () {
       (getBytes).should.be.ok;
@@ -44,7 +44,7 @@ describe("crypto.js", function () {
     });
 
     it("should return Buffer of simply transaction and buffer must be 202 length", function () {
-      var transaction = {
+      const transaction = {
         type: 0,
         amount: 1000,
         fee: 2000,
@@ -63,7 +63,7 @@ describe("crypto.js", function () {
     });
 
     it("should return Buffer of transaction with second signature and buffer must be 266 length", function () {
-      var transaction = {
+      const transaction = {
         type: 0,
         amount: 1000,
         fee: 2000,
@@ -84,7 +84,7 @@ describe("crypto.js", function () {
   });
 
   describe("#getHash", function () {
-    var getHash = crypto.getHash;
+    const getHash = crypto.getHash;
 
     it("should be ok", function () {
       (getHash).should.be.ok;
@@ -95,7 +95,7 @@ describe("crypto.js", function () {
     })
 
     it("should return Buffer and Buffer most be 32 bytes length", function () {
-      var transaction = {
+      const transaction = {
         type: 0,
         amount: 1000,
         fee: 2000,
@@ -106,7 +106,7 @@ describe("crypto.js", function () {
         signature: "618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a",
       };
 
-      var result = getHash(transaction);
+      const result = getHash(transaction);
       (result).should.be.ok;
       (result).should.be.type("object");
       (result.length).should.be.equal(32);
@@ -114,7 +114,7 @@ describe("crypto.js", function () {
   });
 
   describe("#getId", function () {
-    var getId = crypto.getId;
+    const getId = crypto.getId;
 
     it("should be ok", function () {
       (getId).should.be.ok;
@@ -125,7 +125,7 @@ describe("crypto.js", function () {
     });
 
     it("should return string id and be equal to 619fd7971db6f317fdee3675c862291c976d072a0a1782410e3a6f5309022491", function () {
-      var transaction = {
+      const transaction = {
         type: 0,
         amount: 1000,
         fee: 2000,
@@ -136,13 +136,13 @@ describe("crypto.js", function () {
         signature: "618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a"
       };
 
-      var id = getId(transaction);
+      const id = getId(transaction);
       (id).should.be.type("string").and.equal("952e33b66c35a3805015657c008e73a0dee1efefd9af8c41adb59fe79745ccea");
     });
   });
 
   describe("#getFee", function () {
-    var getFee = crypto.getFee;
+    const getFee = crypto.getFee;
 
     it("should be ok", function () {
       (getFee).should.be.ok;
@@ -153,34 +153,34 @@ describe("crypto.js", function () {
     });
 
     it("should return number", function () {
-      var fee = getFee({amount: 100000, type: 0});
+      const fee = getFee({amount: 100000, type: 0});
       (fee).should.be.type("number");
       (fee).should.be.not.NaN;
     });
 
     it("should return 10000000", function () {
-      var fee = getFee({amount: 100000, type: 0});
+      const fee = getFee({amount: 100000, type: 0});
       (fee).should.be.type("number").and.equal(10000000);
     });
 
     it("should return 10000000000", function () {
-      var fee = getFee({type: 1});
+      const fee = getFee({type: 1});
       (fee).should.be.type("number").and.equal(10000000000);
     });
 
     it("should be equal 1000000000000", function () {
-      var fee = getFee({type: 2});
+      const fee = getFee({type: 2});
       (fee).should.be.type("number").and.equal(1000000000000);
     });
 
     it("should be equal 100000000", function () {
-      var fee = getFee({type: 3});
+      const fee = getFee({type: 3});
       (fee).should.be.type("number").and.equal(100000000);
     });
   });
 
   describe("fixedPoint", function () {
-    var fixedPoint = crypto.fixedPoint;
+    const fixedPoint = crypto.fixedPoint;
 
     it("should be ok", function () {
       (fixedPoint).should.be.ok;
@@ -196,7 +196,7 @@ describe("crypto.js", function () {
   });
 
   describe("#sign", function () {
-    var sign = crypto.sign;
+    const sign = crypto.sign;
 
     it("should be ok", function () {
       (sign).should.be.ok;
@@ -208,7 +208,7 @@ describe("crypto.js", function () {
   });
 
   describe("#secondSign", function () {
-    var secondSign = crypto.secondSign;
+    const secondSign = crypto.secondSign;
 
     it("should be ok", function () {
       (secondSign).should.be.ok;
@@ -220,7 +220,7 @@ describe("crypto.js", function () {
   });
 
   describe("#getKeys", function () {
-    var getKeys = crypto.getKeys;
+    const getKeys = crypto.getKeys;
 
     it("should be ok", function () {
       (getKeys).should.be.ok;
@@ -231,7 +231,7 @@ describe("crypto.js", function () {
     });
 
     it("should return two keys in hex", function () {
-      var keys = getKeys("secret");
+      const keys = getKeys("secret");
 
       (keys).should.be.ok;
       (keys).should.be.type("object");
@@ -259,7 +259,7 @@ describe("crypto.js", function () {
   });
 
   describe("#getAddress", function () {
-    var getAddress = crypto.getAddress;
+    const getAddress = crypto.getAddress;
 
     it("should be ok", function () {
       (getAddress).should.be.ok;
@@ -270,8 +270,8 @@ describe("crypto.js", function () {
     });
 
     it("should generate address by publicKey", function () {
-      var keys = crypto.getKeys("secret");
-      var address = getAddress(keys.publicKey);
+      const keys = crypto.getKeys("secret");
+      const address = getAddress(keys.publicKey);
 
       (address).should.be.ok;
       (address).should.be.type("string");
@@ -279,8 +279,8 @@ describe("crypto.js", function () {
     });
 
     it("should generate address by publicKey - second test", function () {
-      var keys = crypto.getKeys("secret second test to be sure it works correctly");
-      var address = getAddress(keys.publicKey);
+      const keys = crypto.getKeys("secret second test to be sure it works correctly");
+      const address = getAddress(keys.publicKey);
 
       (address).should.be.ok;
       (address).should.be.type("string");
@@ -288,18 +288,18 @@ describe("crypto.js", function () {
     });
 
     it("should generate the same address as ECPair.getAddress()", function () {
-      var keys = crypto.getKeys("secret second test to be sure it works correctly");
-      var address = getAddress(keys.publicKey);
+      const keys = crypto.getKeys("secret second test to be sure it works correctly");
+      const address = getAddress(keys.publicKey);
 
-      var Q = ecurve.Point.decodeFrom(curve, new Buffer(keys.publicKey, 'hex'))
-      var keyPair = new ECPair(null, Q);
+      const Q = ecurve.Point.decodeFrom(curve, new Buffer(keys.publicKey, 'hex'))
+      const keyPair = new ECPair(null, Q);
 
       (address).should.be.equal(keyPair.getAddress());
     });
   });
 
   describe("#verify", function () {
-    var verify = crypto.verify;
+    const verify = crypto.verify;
 
     it("should be ok", function () {
       (verify).should.be.ok;
@@ -311,7 +311,7 @@ describe("crypto.js", function () {
   });
 
   describe("#verifySecondSignature", function () {
-    var verifySecondSignature = crypto.verifySecondSignature;
+    const verifySecondSignature = crypto.verifySecondSignature;
 
     it("should be ok", function () {
       (verifySecondSignature).should.be.ok;
@@ -328,7 +328,7 @@ describe("different networks", function () {
   it("validate address on tesnet should be ok", function () {
     ark.crypto.setNetworkVersion(0x52);
     ark.crypto.getNetworkVersion().should.equal(0x52);
-    var validate = ark.crypto.validateAddress("a6fpb1BJZq4otWiVsBcuLG1ZGs5WsqqQtH");
+    const validate = ark.crypto.validateAddress("a6fpb1BJZq4otWiVsBcuLG1ZGs5WsqqQtH");
     (validate).should.equal(true);
     ark.crypto.setNetworkVersion(0x17);
     ark.crypto.getNetworkVersion().should.equal(0x17);
@@ -336,7 +336,7 @@ describe("different networks", function () {
 });
 
 describe("delegate.js", function () {
-  var delegate = ark.delegate;
+  const delegate = ark.delegate;
 
   it("should be ok", function () {
     (delegate).should.be.ok;
@@ -351,8 +351,8 @@ describe("delegate.js", function () {
   });
 
   describe("#createDelegate", function () {
-    var createDelegate = delegate.createDelegate;
-    var trs = null;
+    const createDelegate = delegate.createDelegate;
+    let trs = null;
 
     it("should be ok", function () {
       (createDelegate).should.be.ok;
@@ -367,10 +367,10 @@ describe("delegate.js", function () {
     });
 
     it("should be deserialised correctly", function () {
-      var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
+      const deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
       delete deserialisedTx.vendorFieldHex;
-      var keys = Object.keys(deserialisedTx)
-      for(var key in keys){
+      const keys = Object.keys(deserialisedTx)
+      for(const key in keys){
         if(keys[key] == "asset"){
           deserialisedTx.asset.delegate.username.should.equal(trs.asset.delegate.username);
         }
@@ -381,8 +381,8 @@ describe("delegate.js", function () {
     });
 
     describe("returned delegate", function () {
-      var keys = ark.crypto.getKeys("secret");
-      var secondKeys = ark.crypto.getKeys("secret 2");
+      const keys = ark.crypto.getKeys("secret");
+      const secondKeys = ark.crypto.getKeys("secret 2");
 
       it("should be ok", function () {
         (trs).should.be.ok;
@@ -454,24 +454,24 @@ describe("delegate.js", function () {
       })
 
       it("should be signed correctly", function () {
-        var result = ark.crypto.verify(trs);
+        const result = ark.crypto.verify(trs);
         (result).should.be.ok;
       });
 
       it("should be second signed correctly", function () {
-        var result = ark.crypto.verifySecondSignature(trs, secondKeys.publicKey);
+        const result = ark.crypto.verifySecondSignature(trs, secondKeys.publicKey);
         (result).should.be.ok;
       });
 
       it("should not be signed correctly now", function () {
         trs.amount = 100;
-        var result = ark.crypto.verify(trs);
+        const result = ark.crypto.verify(trs);
         (result).should.be.not.ok;
       });
 
       it("should not be second signed correctly now", function () {
         trs.amount = 100;
-        var result = ark.crypto.verifySecondSignature(trs, secondKeys.publicKey);
+        const result = ark.crypto.verifySecondSignature(trs, secondKeys.publicKey);
         (result).should.be.not.ok;
       });
 

--- a/test/crypto/index.js
+++ b/test/crypto/index.js
@@ -1,5 +1,7 @@
+/* eslint-disable max-len */
+
+require("should");
 var Buffer = require("buffer/").Buffer;
-var should = require("should");
 var ark = require("../../index.js");
 var ECPair = require('../../lib/ecpair');
 
@@ -20,7 +22,10 @@ describe("crypto.js", function () {
   });
 
   it("should has properties", function () {
-    var properties = ["getBytes", "getHash", "getId", "getFee", "sign", "secondSign", "getKeys", "getAddress", "verify", "verifySecondSignature", "fixedPoint"];
+    var properties = [
+      "getBytes", "getHash", "getId", "getFee", "sign", "secondSign",
+      "getKeys", "getAddress", "verify", "verifySecondSignature", "fixedPoint"
+    ];
     properties.forEach(function (property) {
       (crypto).should.have.property(property);
     });
@@ -365,7 +370,7 @@ describe("delegate.js", function () {
       var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
       delete deserialisedTx.vendorFieldHex;
       var keys = Object.keys(deserialisedTx)
-      for(key in keys){
+      for(var key in keys){
         if(keys[key] == "asset"){
           deserialisedTx.asset.delegate.username.should.equal(trs.asset.delegate.username);
         }

--- a/test/ecdsa/index.js
+++ b/test/ecdsa/index.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 var assert = require('assert')
 var bcrypto = require('../../lib/crypto')
 var ecdsa = require('../../lib/ecdsa')

--- a/test/ecdsa/index.js
+++ b/test/ecdsa/index.js
@@ -1,14 +1,14 @@
-var assert = require('assert')
-var bcrypto = require('../../lib/crypto')
-var ecdsa = require('../../lib/ecdsa')
-var sinon = require('sinon')
+const assert = require('assert')
+const bcrypto = require('../../lib/crypto')
+const ecdsa = require('../../lib/ecdsa')
+const sinon = require('sinon')
 
-var BigInteger = require('bigi')
-var ECSignature = require('../../lib/ecsignature')
+const BigInteger = require('bigi')
+const ECSignature = require('../../lib/ecsignature')
 
-var curve = ecdsa.__curve
+const curve = ecdsa.__curve
 
-var fixtures = require('./fixtures.json')
+const fixtures = require('./fixtures.json')
 
 describe('ecdsa', function () {
   describe('deterministicGenerateK', function () {
@@ -18,10 +18,10 @@ describe('ecdsa', function () {
 
     fixtures.valid.ecdsa.forEach(function (f) {
       it('for "' + f.message + '"', function () {
-        var x = BigInteger.fromHex(f.d).toBuffer(32)
-        var h1 = bcrypto.sha256(f.message)
+        const x = BigInteger.fromHex(f.d).toBuffer(32)
+        const h1 = bcrypto.sha256(f.message)
 
-        var k = ecdsa.deterministicGenerateK(h1, x, checkSig)
+        const k = ecdsa.deterministicGenerateK(h1, x, checkSig)
         assert.strictEqual(k.toHex(), f.k)
       })
     })
@@ -33,9 +33,9 @@ describe('ecdsa', function () {
         .onCall(1).returns(curve.n) // > n-1
         .onCall(2).returns(new BigInteger('42')) // valid
 
-      var x = new BigInteger('1').toBuffer(32)
-      var h1 = new Buffer(32)
-      var k = ecdsa.deterministicGenerateK(h1, x, checkSig)
+      const x = new BigInteger('1').toBuffer(32)
+      const h1 = new Buffer(32)
+      const k = ecdsa.deterministicGenerateK(h1, x, checkSig)
 
       assert.strictEqual(k.toString(), '42')
     }))
@@ -48,24 +48,24 @@ describe('ecdsa', function () {
         .onCall(2).returns(new BigInteger('42')) // valid, but 'bad' signature
         .onCall(3).returns(new BigInteger('53')) // valid, good signature
 
-      var checkSig = this.mock()
+      const checkSig = this.mock()
       checkSig.exactly(2)
       checkSig.onCall(0).returns(false) // bad signature
       checkSig.onCall(1).returns(true) // good signature
 
-      var x = new BigInteger('1').toBuffer(32)
-      var h1 = new Buffer(32)
-      var k = ecdsa.deterministicGenerateK(h1, x, checkSig)
+      const x = new BigInteger('1').toBuffer(32)
+      const h1 = new Buffer(32)
+      const k = ecdsa.deterministicGenerateK(h1, x, checkSig)
 
       assert.strictEqual(k.toString(), '53')
     }))
 
     fixtures.valid.rfc6979.forEach(function (f) {
       it('produces the expected k values for ' + f.message + " if k wasn't suitable", function () {
-        var x = BigInteger.fromHex(f.d).toBuffer(32)
-        var h1 = bcrypto.sha256(f.message)
+        const x = BigInteger.fromHex(f.d).toBuffer(32)
+        const h1 = bcrypto.sha256(f.message)
 
-        var results = []
+        const results = []
         ecdsa.deterministicGenerateK(h1, x, function (k) {
           results.push(k)
 
@@ -82,20 +82,20 @@ describe('ecdsa', function () {
   describe('sign', function () {
     fixtures.valid.ecdsa.forEach(function (f) {
       it('produces a deterministic signature for "' + f.message + '"', function () {
-        var d = BigInteger.fromHex(f.d)
-        var hash = bcrypto.sha256(f.message)
-        var signature = ecdsa.sign(hash, d).toDER()
+        const d = BigInteger.fromHex(f.d)
+        const hash = bcrypto.sha256(f.message)
+        const signature = ecdsa.sign(hash, d).toDER()
 
         assert.strictEqual(signature.toString('hex'), f.signature)
       })
     })
 
     it('should sign with low S value', function () {
-      var hash = bcrypto.sha256('Vires in numeris')
-      var sig = ecdsa.sign(hash, BigInteger.ONE)
+      const hash = bcrypto.sha256('Vires in numeris')
+      const sig = ecdsa.sign(hash, BigInteger.ONE)
 
       // See BIP62 for more information
-      var N_OVER_TWO = curve.n.shiftRight(1)
+      const N_OVER_TWO = curve.n.shiftRight(1)
       assert(sig.s.compareTo(N_OVER_TWO) <= 0)
     })
   })
@@ -103,10 +103,10 @@ describe('ecdsa', function () {
   describe('verify', function () {
     fixtures.valid.ecdsa.forEach(function (f) {
       it('verifies a valid signature for "' + f.message + '"', function () {
-        var d = BigInteger.fromHex(f.d)
-        var H = bcrypto.sha256(f.message)
-        var signature = ECSignature.fromDER(new Buffer(f.signature, 'hex'))
-        var Q = curve.G.multiply(d)
+        const d = BigInteger.fromHex(f.d)
+        const H = bcrypto.sha256(f.message)
+        const signature = ECSignature.fromDER(new Buffer(f.signature, 'hex'))
+        const Q = curve.G.multiply(d)
 
         assert(ecdsa.verify(H, signature, Q))
       })
@@ -114,17 +114,17 @@ describe('ecdsa', function () {
 
     fixtures.invalid.verify.forEach(function (f) {
       it('fails to verify with ' + f.description, function () {
-        var H = bcrypto.sha256(f.message)
-        var d = BigInteger.fromHex(f.d)
+        const H = bcrypto.sha256(f.message)
+        const d = BigInteger.fromHex(f.d)
 
-        var signature
+        let signature
         if (f.signature) {
           signature = ECSignature.fromDER(new Buffer(f.signature, 'hex'))
         } else if (f.signatureRaw) {
           signature = new ECSignature(new BigInteger(f.signatureRaw.r, 16), new BigInteger(f.signatureRaw.s, 16))
         }
 
-        var Q = curve.G.multiply(d)
+        const Q = curve.G.multiply(d)
 
         assert.strictEqual(ecdsa.verify(H, signature, Q), false)
       })

--- a/test/ecpair/index.js
+++ b/test/ecpair/index.js
@@ -1,31 +1,31 @@
-var assert = require('assert')
-var ecdsa = require('../../lib/ecdsa')
-var ecurve = require('ecurve')
-var proxyquire = require('proxyquire')
-var sinon = require('sinon')
+const assert = require('assert')
+const ecdsa = require('../../lib/ecdsa')
+const ecurve = require('ecurve')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
 
-var BigInteger = require('bigi')
-var ECPair = require('../../lib/ecpair')
+const BigInteger = require('bigi')
+const ECPair = require('../../lib/ecpair')
 
-var fixtures = require('./fixtures.json')
-var curve = ecdsa.__curve
+const fixtures = require('./fixtures.json')
+const curve = ecdsa.__curve
 
-var NETWORKS = require('../../lib/networks')
-var NETWORKS_LIST = [] // Object.values(NETWORKS)
-for (var networkName in NETWORKS) {
+const NETWORKS = require('../../lib/networks')
+const NETWORKS_LIST = [] // Object.values(NETWORKS)
+for (const networkName in NETWORKS) {
   NETWORKS_LIST.push(NETWORKS[networkName])
 }
 
 describe('ECPair', function () {
   describe('constructor', function () {
     it('defaults to compressed', function () {
-      var keyPair = new ECPair(BigInteger.ONE)
+      const keyPair = new ECPair(BigInteger.ONE)
 
       assert.strictEqual(keyPair.compressed, true)
     })
 
     it('supports the uncompressed option', function () {
-      var keyPair = new ECPair(BigInteger.ONE, null, {
+      const keyPair = new ECPair(BigInteger.ONE, null, {
         compressed: false
       })
 
@@ -33,7 +33,7 @@ describe('ECPair', function () {
     })
 
     it('supports the network option', function () {
-      var keyPair = new ECPair(BigInteger.ONE, null, {
+      const keyPair = new ECPair(BigInteger.ONE, null, {
         compressed: false,
         network: NETWORKS.testnet
       })
@@ -43,8 +43,8 @@ describe('ECPair', function () {
 
     fixtures.valid.forEach(function (f) {
       it('calculates the public point for ' + f.WIF, function () {
-        var d = new BigInteger(f.d)
-        var keyPair = new ECPair(d, null, {
+        const d = new BigInteger(f.d)
+        const keyPair = new ECPair(d, null, {
           compressed: f.compressed
         })
 
@@ -54,8 +54,8 @@ describe('ECPair', function () {
 
     fixtures.invalid.constructor.forEach(function (f) {
       it('throws ' + f.exception, function () {
-        var d = f.d && new BigInteger(f.d)
-        var Q = f.Q && ecurve.Point.decodeFrom(curve, new Buffer(f.Q, 'hex'))
+        const d = f.d && new BigInteger(f.d)
+        const Q = f.Q && ecurve.Point.decodeFrom(curve, new Buffer(f.Q, 'hex'))
 
         assert.throws(function () {
           new ECPair(d, Q, f.options)
@@ -65,7 +65,7 @@ describe('ECPair', function () {
   })
 
   describe('getPublicKeyBuffer', function () {
-    var keyPair
+    let keyPair
 
     beforeEach(function () {
       keyPair = new ECPair(BigInteger.ONE)
@@ -82,8 +82,8 @@ describe('ECPair', function () {
   describe('fromWIF', function () {
     fixtures.valid.forEach(function (f) {
       it('imports ' + f.WIF + ' (' + f.network + ')', function () {
-        var network = NETWORKS[f.network]
-        var keyPair = ECPair.fromWIF(f.WIF, network)
+        const network = NETWORKS[f.network]
+        const keyPair = ECPair.fromWIF(f.WIF, network)
 
         assert.strictEqual(keyPair.d.toString(), f.d)
         assert.strictEqual(keyPair.getPublicKeyBuffer().toString("hex"), f.Q)
@@ -94,7 +94,7 @@ describe('ECPair', function () {
 
     fixtures.valid.forEach(function (f) {
       it('imports ' + f.WIF + ' (via list of networks)', function () {
-        var keyPair = ECPair.fromWIF(f.WIF, NETWORKS_LIST)
+        const keyPair = ECPair.fromWIF(f.WIF, NETWORKS_LIST)
 
         assert.strictEqual(keyPair.d.toString(), f.d)
         assert.strictEqual(keyPair.getPublicKeyBuffer().toString("hex"), f.Q)
@@ -106,7 +106,7 @@ describe('ECPair', function () {
     fixtures.invalid.fromWIF.forEach(function (f) {
       it('throws on ' + f.WIF, function () {
         assert.throws(function () {
-          var networks = f.network ? NETWORKS[f.network] : NETWORKS_LIST
+          const networks = f.network ? NETWORKS[f.network] : NETWORKS_LIST
 
           ECPair.fromWIF(f.WIF, networks)
         }, new RegExp(f.exception))
@@ -117,8 +117,8 @@ describe('ECPair', function () {
   describe('toWIF', function () {
     fixtures.valid.forEach(function (f) {
       it('exports ' + f.WIF, function () {
-        var keyPair = ECPair.fromWIF(f.WIF, NETWORKS_LIST)
-        var result = keyPair.toWIF()
+        const keyPair = ECPair.fromWIF(f.WIF, NETWORKS_LIST)
+        const result = keyPair.toWIF()
 
         assert.strictEqual(result, f.WIF)
       })
@@ -126,21 +126,21 @@ describe('ECPair', function () {
   })
 
   describe('makeRandom', function () {
-    var d = new Buffer('0404040404040404040404040404040404040404040404040404040404040404', 'hex')
-    var exWIF = 'S9hzwiZ5ziKjUiFpuZX4Lri3rUocDxZSTy7YzKKHvx8TSjUrYQ27'
+    const d = new Buffer('0404040404040404040404040404040404040404040404040404040404040404', 'hex')
+    const exWIF = 'S9hzwiZ5ziKjUiFpuZX4Lri3rUocDxZSTy7YzKKHvx8TSjUrYQ27'
 
     describe('uses randombytes RNG', function () {
       it('generates a ECPair', function () {
-        var stub = { randombytes: function () { return d } }
-        var ProxiedECPair = proxyquire('../../lib/ecpair', stub)
+        const stub = { randombytes: function () { return d } }
+        const ProxiedECPair = proxyquire('../../lib/ecpair', stub)
 
-        var keyPair = ProxiedECPair.makeRandom()
+        const keyPair = ProxiedECPair.makeRandom()
         assert.strictEqual(keyPair.toWIF(), exWIF)
       })
     })
 
     it('allows a custom RNG to be used', function () {
-      var keyPair = ECPair.makeRandom({
+      const keyPair = ECPair.makeRandom({
         rng: function (size) { return d.slice(0, size) }
       })
 
@@ -148,14 +148,14 @@ describe('ECPair', function () {
     })
 
     it('retains the same defaults as ECPair constructor', function () {
-      var keyPair = ECPair.makeRandom()
+      const keyPair = ECPair.makeRandom()
 
       assert.strictEqual(keyPair.compressed, true)
       assert.strictEqual(keyPair.network, NETWORKS.ark)
     })
 
     it('supports the options parameter', function () {
-      var keyPair = ECPair.makeRandom({
+      const keyPair = ECPair.makeRandom({
         compressed: false,
         network: NETWORKS.testnet
       })
@@ -165,7 +165,7 @@ describe('ECPair', function () {
     })
 
     it('loops until d is within interval [1, n - 1] : 1', sinon.test(function () {
-      var rng = this.mock()
+      const rng = this.mock()
       rng.exactly(2)
       rng.onCall(0).returns(BigInteger.ZERO.toBuffer(32)) // invalid length
       rng.onCall(1).returns(BigInteger.ONE.toBuffer(32)) // === 1
@@ -174,7 +174,7 @@ describe('ECPair', function () {
     }))
 
     it('loops until d is within interval [1, n - 1] : n - 1', sinon.test(function () {
-      var rng = this.mock()
+      const rng = this.mock()
       rng.exactly(3)
       rng.onCall(0).returns(BigInteger.ZERO.toBuffer(32)) // < 1
       rng.onCall(1).returns(curve.n.toBuffer(32)) // > n-1
@@ -187,7 +187,7 @@ describe('ECPair', function () {
   describe('getAddress', function () {
     fixtures.valid.forEach(function (f) {
       it('returns ' + f.address + ' for ' + f.WIF, function () {
-        var keyPair = ECPair.fromWIF(f.WIF, NETWORKS_LIST)
+        const keyPair = ECPair.fromWIF(f.WIF, NETWORKS_LIST)
 
         assert.strictEqual(keyPair.getAddress(), f.address)
       })
@@ -197,8 +197,8 @@ describe('ECPair', function () {
   describe('getNetwork', function () {
     fixtures.valid.forEach(function (f) {
       it('returns ' + f.network + ' for ' + f.WIF, function () {
-        var network = NETWORKS[f.network]
-        var keyPair = ECPair.fromWIF(f.WIF, NETWORKS_LIST)
+        const network = NETWORKS[f.network]
+        const keyPair = ECPair.fromWIF(f.WIF, NETWORKS_LIST)
 
         assert.strictEqual(keyPair.getNetwork(), network)
       })
@@ -206,7 +206,7 @@ describe('ECPair', function () {
   })
 
   describe('ecdsa wrappers', function () {
-    var keyPair, hash
+    let keyPair, hash
 
     beforeEach(function () {
       keyPair = ECPair.makeRandom()

--- a/test/ecpair/index.js
+++ b/test/ecpair/index.js
@@ -230,19 +230,19 @@ describe('ECPair', function () {
       })
     })
 
-    describe('verify', function () {
-      // var signature
-      //
-      // beforeEach(function () {
-      //   signature = keyPair.sign(hash)
-      // })
-      //
-      // it('wraps ecdsa.verify', sinon.test(function () {
-      //   this.mock(ecdsa).expects('verify')
-      //     .once().withArgs(hash, signature, keyPair.Q)
-      //
-      //   keyPair.verify(hash, signature)
-      // }))
-    })
+    // describe('verify', function () {
+    //   var signature
+    //
+    //   beforeEach(function () {
+    //     signature = keyPair.sign(hash)
+    //   })
+    //
+    //   it('wraps ecdsa.verify', sinon.test(function () {
+    //     this.mock(ecdsa).expects('verify')
+    //       .once().withArgs(hash, signature, keyPair.Q)
+    //
+    //     keyPair.verify(hash, signature)
+    //   }))
+    // })
   })
 })

--- a/test/ecpair/index.js
+++ b/test/ecpair/index.js
@@ -1,6 +1,3 @@
-/* global describe, it, beforeEach */
-/* eslint-disable no-new */
-
 var assert = require('assert')
 var ecdsa = require('../../lib/ecdsa')
 var ecurve = require('ecurve')
@@ -234,12 +231,12 @@ describe('ECPair', function () {
     })
 
     describe('verify', function () {
-      var signature
-
-      beforeEach(function () {
-        signature = keyPair.sign(hash)
-      })
-
+      // var signature
+      //
+      // beforeEach(function () {
+      //   signature = keyPair.sign(hash)
+      // })
+      //
       // it('wraps ecdsa.verify', sinon.test(function () {
       //   this.mock(ecdsa).expects('verify')
       //     .once().withArgs(hash, signature, keyPair.Q)

--- a/test/ecsignature/index.js
+++ b/test/ecsignature/index.js
@@ -1,17 +1,17 @@
-var assert = require('assert')
+const assert = require('assert')
 
-var BigInteger = require('bigi')
-var ECSignature = require('../../lib/ecsignature')
+const BigInteger = require('bigi')
+const ECSignature = require('../../lib/ecsignature')
 
-var fixtures = require('./fixtures.json')
+const fixtures = require('./fixtures.json')
 
 describe('ECSignature', function () {
   describe('toCompact', function () {
     fixtures.valid.forEach(function (f) {
       it('exports ' + f.compact.hex + ' correctly', function () {
-        var signature = new ECSignature(new BigInteger(f.signature.r), new BigInteger(f.signature.s))
+        const signature = new ECSignature(new BigInteger(f.signature.r), new BigInteger(f.signature.s))
 
-        var buffer = signature.toCompact(f.compact.i, f.compact.compressed)
+        const buffer = signature.toCompact(f.compact.i, f.compact.compressed)
         assert.strictEqual(buffer.toString('hex'), f.compact.hex)
       })
     })
@@ -20,8 +20,8 @@ describe('ECSignature', function () {
   describe('parseCompact', function () {
     fixtures.valid.forEach(function (f) {
       it('imports ' + f.compact.hex + ' correctly', function () {
-        var buffer = new Buffer(f.compact.hex, 'hex')
-        var parsed = ECSignature.parseCompact(buffer)
+        const buffer = new Buffer(f.compact.hex, 'hex')
+        const parsed = ECSignature.parseCompact(buffer)
 
         assert.strictEqual(parsed.compressed, f.compact.compressed)
         assert.strictEqual(parsed.i, f.compact.i)
@@ -32,7 +32,7 @@ describe('ECSignature', function () {
 
     fixtures.invalid.compact.forEach(function (f) {
       it('throws on ' + f.hex, function () {
-        var buffer = new Buffer(f.hex, 'hex')
+        const buffer = new Buffer(f.hex, 'hex')
 
         assert.throws(function () {
           ECSignature.parseCompact(buffer)
@@ -44,9 +44,9 @@ describe('ECSignature', function () {
   describe('toDER', function () {
     fixtures.valid.forEach(function (f) {
       it('exports ' + f.DER + ' correctly', function () {
-        var signature = new ECSignature(new BigInteger(f.signature.r), new BigInteger(f.signature.s))
+        const signature = new ECSignature(new BigInteger(f.signature.r), new BigInteger(f.signature.s))
 
-        var DER = signature.toDER()
+        const DER = signature.toDER()
         assert.strictEqual(DER.toString('hex'), f.DER)
       })
     })
@@ -55,8 +55,8 @@ describe('ECSignature', function () {
   describe('fromDER', function () {
     fixtures.valid.forEach(function (f) {
       it('imports ' + f.DER + ' correctly', function () {
-        var buffer = new Buffer(f.DER, 'hex')
-        var signature = ECSignature.fromDER(buffer)
+        const buffer = new Buffer(f.DER, 'hex')
+        const signature = ECSignature.fromDER(buffer)
 
         assert.strictEqual(signature.r.toString(), f.signature.r)
         assert.strictEqual(signature.s.toString(), f.signature.s)
@@ -65,7 +65,7 @@ describe('ECSignature', function () {
 
     fixtures.invalid.DER.forEach(function (f) {
       it('throws "' + f.exception + '" for ' + f.hex, function () {
-        var buffer = new Buffer(f.hex, 'hex')
+        const buffer = new Buffer(f.hex, 'hex')
 
         assert.throws(function () {
           ECSignature.fromDER(buffer)
@@ -77,16 +77,16 @@ describe('ECSignature', function () {
   describe('toScriptSignature', function () {
     fixtures.valid.forEach(function (f) {
       it('exports ' + f.scriptSignature.hex + ' correctly', function () {
-        var signature = new ECSignature(new BigInteger(f.signature.r), new BigInteger(f.signature.s))
+        const signature = new ECSignature(new BigInteger(f.signature.r), new BigInteger(f.signature.s))
 
-        var scriptSignature = signature.toScriptSignature(f.scriptSignature.hashType)
+        const scriptSignature = signature.toScriptSignature(f.scriptSignature.hashType)
         assert.strictEqual(scriptSignature.toString('hex'), f.scriptSignature.hex)
       })
     })
 
     fixtures.invalid.scriptSignature.forEach(function (f) {
       it('throws ' + f.exception, function () {
-        var signature = new ECSignature(new BigInteger(f.signature.r), new BigInteger(f.signature.s))
+        const signature = new ECSignature(new BigInteger(f.signature.r), new BigInteger(f.signature.s))
 
         assert.throws(function () {
           signature.toScriptSignature(f.hashType)
@@ -98,8 +98,8 @@ describe('ECSignature', function () {
   describe('parseScriptSignature', function () {
     fixtures.valid.forEach(function (f) {
       it('imports ' + f.scriptSignature.hex + ' correctly', function () {
-        var buffer = new Buffer(f.scriptSignature.hex, 'hex')
-        var parsed = ECSignature.parseScriptSignature(buffer)
+        const buffer = new Buffer(f.scriptSignature.hex, 'hex')
+        const parsed = ECSignature.parseScriptSignature(buffer)
 
         assert.strictEqual(parsed.signature.r.toString(), f.signature.r)
         assert.strictEqual(parsed.signature.s.toString(), f.signature.s)
@@ -109,7 +109,7 @@ describe('ECSignature', function () {
 
     fixtures.invalid.scriptSignature.forEach(function (f) {
       it('throws on ' + f.hex, function () {
-        var buffer = new Buffer(f.hex, 'hex')
+        const buffer = new Buffer(f.hex, 'hex')
 
         assert.throws(function () {
           ECSignature.parseScriptSignature(buffer)

--- a/test/ecsignature/index.js
+++ b/test/ecsignature/index.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 var assert = require('assert')
 
 var BigInteger = require('bigi')

--- a/test/hdnode/index.js
+++ b/test/hdnode/index.js
@@ -1,23 +1,23 @@
 /* eslint-disable max-len */
 
-var assert = require('assert')
-var ecdsa = require('../../lib/ecdsa')
-var sinon = require('sinon')
+const assert = require('assert')
+const ecdsa = require('../../lib/ecdsa')
+const sinon = require('sinon')
 
-var BigInteger = require('bigi')
-var ECPair = require('../../lib/ecpair')
-var HDNode = require('../../lib/hdnode')
+const BigInteger = require('bigi')
+const ECPair = require('../../lib/ecpair')
+const HDNode = require('../../lib/hdnode')
 
-var fixtures = require('./fixtures.json')
-var curve = ecdsa.__curve
+const fixtures = require('./fixtures.json')
+const curve = ecdsa.__curve
 
-var NETWORKS = require('../../lib/networks')
-var NETWORKS_LIST = [] // Object.values(NETWORKS)
-for (var networkName in NETWORKS) {
+const NETWORKS = require('../../lib/networks')
+const NETWORKS_LIST = [] // Object.values(NETWORKS)
+for (const networkName in NETWORKS) {
   NETWORKS_LIST.push(NETWORKS[networkName])
 }
 
-var validAll = []
+let validAll = []
 fixtures.valid.forEach(function (f) {
   function addNetwork (n) {
     n.network = f.network
@@ -29,10 +29,10 @@ fixtures.valid.forEach(function (f) {
 
 describe('HDNode', function () {
   describe('Constructor', function () {
-    var keyPair, chainCode
+    let keyPair, chainCode
 
     beforeEach(function () {
-      var d = BigInteger.ONE
+      const d = BigInteger.ONE
 
       keyPair = new ECPair(d, null)
       chainCode = new Buffer(32)
@@ -40,14 +40,14 @@ describe('HDNode', function () {
     })
 
     it('stores the keyPair/chainCode directly', function () {
-      var hd = new HDNode(keyPair, chainCode)
+      const hd = new HDNode(keyPair, chainCode)
 
       assert.strictEqual(hd.keyPair, keyPair)
       assert.strictEqual(hd.chainCode, chainCode)
     })
 
     it('has a default depth/index of 0', function () {
-      var hd = new HDNode(keyPair, chainCode)
+      const hd = new HDNode(keyPair, chainCode)
 
       assert.strictEqual(hd.depth, 0)
       assert.strictEqual(hd.index, 0)
@@ -71,8 +71,8 @@ describe('HDNode', function () {
   describe('fromSeed*', function () {
     fixtures.valid.forEach(function (f) {
       it('calculates privKey and chainCode for ' + f.master.fingerprint, function () {
-        var network = NETWORKS[f.network]
-        var hd = HDNode.fromSeedHex(f.master.seed, network)
+        const network = NETWORKS[f.network]
+        const hd = HDNode.fromSeedHex(f.master.seed, network)
 
         assert.strictEqual(hd.keyPair.toWIF(), f.master.wif)
         assert.strictEqual(hd.chainCode.toString('hex'), f.master.chainCode)
@@ -111,13 +111,13 @@ describe('HDNode', function () {
   })
 
   describe('ECPair wrappers', function () {
-    var keyPair, hd, hash
+    let keyPair, hd, hash
 
     beforeEach(function () {
       keyPair = ECPair.makeRandom()
       hash = new Buffer(32)
 
-      var chainCode = new Buffer(32)
+      const chainCode = new Buffer(32)
       hd = new HDNode(keyPair, chainCode)
     })
 
@@ -158,7 +158,7 @@ describe('HDNode', function () {
     })
 
     describe('verify', function () {
-      var signature
+      let signature
 
       beforeEach(function () {
         signature = hd.sign(hash)
@@ -176,7 +176,7 @@ describe('HDNode', function () {
   describe('fromBase58 / toBase58', function () {
     validAll.forEach(function (f) {
       it('exports ' + f.base58 + ' (public) correctly', function () {
-        var hd = HDNode.fromBase58(f.base58, NETWORKS_LIST)
+        const hd = HDNode.fromBase58(f.base58, NETWORKS_LIST)
         
         assert.strictEqual(hd.toBase58(), f.base58)
         assert.throws(function () { hd.keyPair.toWIF() }, /Missing private key/)
@@ -185,7 +185,7 @@ describe('HDNode', function () {
 
     validAll.forEach(function (f) {
       it('exports ' + f.base58Priv + ' (private) correctly', function () {
-        var hd = HDNode.fromBase58(f.base58Priv, NETWORKS_LIST)
+        const hd = HDNode.fromBase58(f.base58Priv, NETWORKS_LIST)
         
         assert.strictEqual(hd.toBase58(), f.base58Priv)
         assert.strictEqual(hd.keyPair.toWIF(), f.wif)
@@ -195,7 +195,7 @@ describe('HDNode', function () {
     fixtures.invalid.fromBase58.forEach(function (f) {
       it('throws on ' + f.string, function () {
         assert.throws(function () {
-          var networks = f.network ? NETWORKS[f.network] : NETWORKS_LIST
+          const networks = f.network ? NETWORKS[f.network] : NETWORKS_LIST
 
           HDNode.fromBase58(f.string, networks)
         }, new RegExp(f.exception))
@@ -206,7 +206,7 @@ describe('HDNode', function () {
   describe('getIdentifier', function () {
     validAll.forEach(function (f) {
       it('returns the identifier for ' + f.fingerprint, function () {
-        var hd = HDNode.fromBase58(f.base58, NETWORKS_LIST)
+        const hd = HDNode.fromBase58(f.base58, NETWORKS_LIST)
 
         assert.strictEqual(hd.getIdentifier().toString('hex'), f.identifier)
       })
@@ -216,7 +216,7 @@ describe('HDNode', function () {
   describe('getFingerprint', function () {
     validAll.forEach(function (f) {
       it('returns the fingerprint for ' + f.fingerprint, function () {
-        var hd = HDNode.fromBase58(f.base58, NETWORKS_LIST)
+        const hd = HDNode.fromBase58(f.base58, NETWORKS_LIST)
 
         assert.strictEqual(hd.getFingerprint().toString('hex'), f.fingerprint)
       })
@@ -226,8 +226,8 @@ describe('HDNode', function () {
   describe('neutered / isNeutered', function () {
     validAll.forEach(function (f) {
       it('drops the private key for ' + f.fingerprint, function () {
-        var hd = HDNode.fromBase58(f.base58Priv, NETWORKS_LIST)
-        var hdn = hd.neutered()
+        const hd = HDNode.fromBase58(f.base58Priv, NETWORKS_LIST)
+        const hdn = hd.neutered()
 
         assert.notEqual(hdn.keyPair, hd.keyPair)
         assert.throws(function () { hdn.keyPair.toWIF() }, /Missing private key/)
@@ -264,15 +264,15 @@ describe('HDNode', function () {
     }
 
     fixtures.valid.forEach(function (f) {
-      var network = NETWORKS[f.network]
-      var hd = HDNode.fromSeedHex(f.master.seed, network)
-      var master = hd
+      const network = NETWORKS[f.network]
+      let hd = HDNode.fromSeedHex(f.master.seed, network)
+      const master = hd
 
       // testing deriving path from master
       f.children.forEach(function (c) {
         it(c.path + ' from ' + f.master.fingerprint + ' by path', function () {
-          var child = master.derivePath(c.path)
-          var childNoM = master.derivePath(c.path.slice(2)) // no m/ on path
+          const child = master.derivePath(c.path)
+          const childNoM = master.derivePath(c.path.slice(2)) // no m/ on path
 
           verifyVector(child, c)
           verifyVector(childNoM, c)
@@ -281,12 +281,12 @@ describe('HDNode', function () {
 
       // testing deriving path from children
       f.children.forEach(function (c, i) {
-        var cn = master.derivePath(c.path)
+        const cn = master.derivePath(c.path)
 
         f.children.slice(i + 1).forEach(function (cc) {
           it(cc.path + ' from ' + c.fingerprint + ' by path', function () {
-            var ipath = cc.path.slice(2).split('/').slice(i + 1).join('/')
-            var child = cn.derivePath(ipath)
+            const ipath = cc.path.slice(2).split('/').slice(i + 1).join('/')
+            const child = cn.derivePath(ipath)
             verifyVector(child, cc)
 
             assert.throws(function () {
@@ -313,40 +313,40 @@ describe('HDNode', function () {
     })
 
     it('works for Private -> public (neutered)', function () {
-      var f = fixtures.valid[1]
-      var c = f.children[0]
+      const f = fixtures.valid[1]
+      const c = f.children[0]
 
-      var master = HDNode.fromBase58(f.master.base58Priv, NETWORKS_LIST)
-      var child = master.derive(c.m).neutered()
+      const master = HDNode.fromBase58(f.master.base58Priv, NETWORKS_LIST)
+      const child = master.derive(c.m).neutered()
 
       assert.strictEqual(child.toBase58(), c.base58)
     })
 
     it('works for Private -> public (neutered, hardened)', function () {
-      var f = fixtures.valid[0]
-      var c = f.children[0]
+      const f = fixtures.valid[0]
+      const c = f.children[0]
 
-      var master = HDNode.fromBase58(f.master.base58Priv, NETWORKS_LIST)
-      var child = master.deriveHardened(c.m).neutered()
+      const master = HDNode.fromBase58(f.master.base58Priv, NETWORKS_LIST)
+      const child = master.deriveHardened(c.m).neutered()
 
       assert.strictEqual(c.base58, child.toBase58())
     })
 
     it('works for Public -> public', function () {
-      var f = fixtures.valid[1]
-      var c = f.children[0]
+      const f = fixtures.valid[1]
+      const c = f.children[0]
 
-      var master = HDNode.fromBase58(f.master.base58, NETWORKS_LIST)
-      var child = master.derive(c.m)
+      const master = HDNode.fromBase58(f.master.base58, NETWORKS_LIST)
+      const child = master.derive(c.m)
 
       assert.strictEqual(c.base58, child.toBase58())
     })
 
     it('throws on Public -> public (hardened)', function () {
-      var f = fixtures.valid[0]
-      var c = f.children[0]
+      const f = fixtures.valid[0]
+      const c = f.children[0]
 
-      var master = HDNode.fromBase58(f.master.base58, NETWORKS_LIST)
+      const master = HDNode.fromBase58(f.master.base58, NETWORKS_LIST)
 
       assert.throws(function () {
         master.deriveHardened(c.m)
@@ -354,8 +354,8 @@ describe('HDNode', function () {
     })
 
     it('throws on wrong types', function () {
-      var f = fixtures.valid[0]
-      var master = HDNode.fromBase58(f.master.base58, NETWORKS_LIST)
+      const f = fixtures.valid[0]
+      const master = HDNode.fromBase58(f.master.base58, NETWORKS_LIST)
 
       fixtures.invalid.derive.forEach(function (fx) {
         assert.throws(function () {
@@ -377,10 +377,10 @@ describe('HDNode', function () {
     })
 
     it('works when private key has leading zeros', function () {
-      var key = 'xprv9s21ZrQH143K3ckY9DgU79uMTJkQRLdbCCVDh81SnxTgPzLLGax6uHeBULTtaEtcAvKjXfT7ZWtHzKjTpujMkUd9dDb8msDeAfnJxrgAYhr'
-      var hdkey = HDNode.fromBase58(key, NETWORKS.bitcoin)
+      const key = 'xprv9s21ZrQH143K3ckY9DgU79uMTJkQRLdbCCVDh81SnxTgPzLLGax6uHeBULTtaEtcAvKjXfT7ZWtHzKjTpujMkUd9dDb8msDeAfnJxrgAYhr'
+      const hdkey = HDNode.fromBase58(key, NETWORKS.bitcoin)
       assert.strictEqual(hdkey.keyPair.d.toBuffer(32).toString('hex'), '00000055378cf5fafb56c711c674143f9b0ee82ab0ba2924f19b64f5ae7cdbfd')
-      var child = hdkey.derivePath('m/44\'/0\'/0\'/0/0\'')
+      const child = hdkey.derivePath('m/44\'/0\'/0\'/0/0\'')
       assert.strictEqual(child.keyPair.d.toBuffer().toString('hex'), '3348069561d2a0fb925e74bf198762acc47dce7db27372257d2d959a9e6f8aeb')
     })
   })

--- a/test/hdnode/index.js
+++ b/test/hdnode/index.js
@@ -1,5 +1,4 @@
-/* global describe, it, beforeEach */
-/* eslint-disable no-new */
+/* eslint-disable max-len */
 
 var assert = require('assert')
 var ecdsa = require('../../lib/ecdsa')
@@ -298,7 +297,7 @@ describe('HDNode', function () {
       })
 
       // FIXME: test data is only testing Private -> private for now
-      f.children.forEach(function (c, i) {
+      f.children.forEach(function (c) {
         if (c.m === undefined) return
 
         it(c.path + ' from ' + f.master.fingerprint, function () {

--- a/test/integration/basic.js
+++ b/test/integration/basic.js
@@ -1,6 +1,6 @@
-var assert = require('assert')
-var bigi = require('bigi')
-var ark = require('../../')
+const assert = require('assert')
+const bigi = require('bigi')
+const ark = require('../../')
 
 describe('ark-js (basic)', function () {
   it('can generate a random ark address', function () {
@@ -8,18 +8,18 @@ describe('ark-js (basic)', function () {
     function rng () { return new Buffer('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz') }
 
     // generate random keyPair
-    var keyPair = ark.ECPair.makeRandom({ rng: rng })
-    var address = keyPair.getAddress()
+    const keyPair = ark.ECPair.makeRandom({ rng: rng })
+    const address = keyPair.getAddress()
 
     assert.strictEqual(address, 'ANoMWEJ9jSdE2FgohBLLXeLzci59BDFsP4')
   })
 
   it('can generate an address from a SHA256 hash', function () {
-    var hash = ark.crypto.sha256('correct horse battery staple')
-    var d = bigi.fromBuffer(hash)
+    const hash = ark.crypto.sha256('correct horse battery staple')
+    const d = bigi.fromBuffer(hash)
 
-    var keyPair = new ark.ECPair(d)
-    var address = keyPair.getAddress()
+    const keyPair = new ark.ECPair(d)
+    const address = keyPair.getAddress()
 
     assert.strictEqual(address, 'AG5AtmiNbgv51eLwAWnRGvkMudVd7anYP2')
   })
@@ -28,19 +28,19 @@ describe('ark-js (basic)', function () {
     // for testing only
     function rng () { return new Buffer('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz') }
 
-    var bitcoin = ark.networks.bitcoin
+    const bitcoin = ark.networks.bitcoin
 
-    var keyPair = ark.ECPair.makeRandom({ network: bitcoin, rng: rng })
-    var wif = keyPair.toWIF()
-    var address = keyPair.getAddress()
+    const keyPair = ark.ECPair.makeRandom({ network: bitcoin, rng: rng })
+    const wif = keyPair.toWIF()
+    const address = keyPair.getAddress()
 
     assert.strictEqual(address, '182UrjSXQHy5DHUp8Xg1Nm5u979SojJY2P')
     assert.strictEqual(wif, 'L1Knwj9W3qK3qMKdTvmg3VfzUs3ij2LETTFhxza9LfD5dngnoLG1')
   })
 
   it('can import an address via WIF', function () {
-    var keyPair = ark.ECPair.fromWIF('S9aCCSFvm8kNeyFb1t6pLb5oJs9tv96ag6uA8Du6UM7zsmsNHQiz')
-    var address = keyPair.getAddress()
+    const keyPair = ark.ECPair.fromWIF('S9aCCSFvm8kNeyFb1t6pLb5oJs9tv96ag6uA8Du6UM7zsmsNHQiz')
+    const address = keyPair.getAddress()
 
     assert.strictEqual(address, 'AcMiVQNHjggC1PyfVSvCcdWZKMisMKj8eo')
   })

--- a/test/integration/basic.js
+++ b/test/integration/basic.js
@@ -1,5 +1,3 @@
-/* global describe, it */
-
 var assert = require('assert')
 var bigi = require('bigi')
 var ark = require('../../')

--- a/test/integration/bip32.js
+++ b/test/integration/bip32.js
@@ -1,22 +1,22 @@
 /* global describe, it */
 
-var assert = require('assert')
-var bigi = require('bigi')
-var ark = require('../../')
-var crypto = require('crypto')
+const assert = require('assert')
+const bigi = require('bigi')
+const ark = require('../../')
+const crypto = require('crypto')
 
-var ecurve = require('ecurve')
-var secp256k1 = ecurve.getCurveByName('secp256k1')
+const ecurve = require('ecurve')
+const secp256k1 = ecurve.getCurveByName('secp256k1')
 
 describe('ark-js (BIP32)', function () {
   it('can create a BIP32 wallet external address', function () {
-    var path = "m/0'/0/0"
-    var root = ark.HDNode.fromSeedHex('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd')
+    const path = "m/0'/0/0"
+    const root = ark.HDNode.fromSeedHex('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd')
 
-    var child1 = root.derivePath(path)
+    const child1 = root.derivePath(path)
 
     // option 2, manually
-    var child2 = root.deriveHardened(0)
+    const child2 = root.deriveHardened(0)
       .derive(0)
       .derive(0)
 
@@ -25,13 +25,13 @@ describe('ark-js (BIP32)', function () {
   })
 
   it('can create a BIP44, ark, account 0, external address', function () {
-    var path = "m/44'/0'/0'/0/0"
-    var root = ark.HDNode.fromSeedHex('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd')
+    const path = "m/44'/0'/0'/0/0"
+    const root = ark.HDNode.fromSeedHex('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd')
 
-    var child1 = root.derivePath(path)
+    const child1 = root.derivePath(path)
 
     // option 2, manually
-    var child2 = root.deriveHardened(44)
+    const child2 = root.deriveHardened(44)
       .deriveHardened(0)
       .deriveHardened(0)
       .derive(0)
@@ -46,45 +46,45 @@ describe('ark-js (BIP32)', function () {
       assert(!master.keyPair.d, 'You already have the parent private key')
       assert(child.keyPair.d, 'Missing child private key')
 
-      var curve = secp256k1
-      var QP = master.keyPair.Q
-      var serQP = master.keyPair.getPublicKeyBuffer()
+      const curve = secp256k1
+      const QP = master.keyPair.Q
+      const serQP = master.keyPair.getPublicKeyBuffer()
 
-      var d1 = child.keyPair.d
-      var d2
-      var data = new Buffer(37)
+      const d1 = child.keyPair.d
+      let d2
+      const data = new Buffer(37)
       serQP.copy(data, 0)
 
       // search index space until we find it
-      for (var i = 0; i < ark.HDNode.HIGHEST_BIT; ++i) {
+      for (let i = 0; i < ark.HDNode.HIGHEST_BIT; ++i) {
         data.writeUInt32BE(i, 33)
 
         // calculate I
-        var I = crypto.createHmac('sha512', master.chainCode).update(data).digest()
-        var IL = I.slice(0, 32)
-        var pIL = bigi.fromBuffer(IL)
+        const I = crypto.createHmac('sha512', master.chainCode).update(data).digest()
+        const IL = I.slice(0, 32)
+        const pIL = bigi.fromBuffer(IL)
 
         // See hdnode.js:273 to understand
         d2 = d1.subtract(pIL).mod(curve.n)
 
-        var Qp = new ark.ECPair(d2).Q
+        const Qp = new ark.ECPair(d2).Q
         if (Qp.equals(QP)) break
       }
 
-      var node = new ark.HDNode(new ark.ECPair(d2), master.chainCode, master.network)
+      const node = new ark.HDNode(new ark.ECPair(d2), master.chainCode, master.network)
       node.depth = master.depth
       node.index = master.index
       node.masterFingerprint = master.masterFingerprint
       return node
     }
 
-    var seed = crypto.randomBytes(32)
-    var master = ark.HDNode.fromSeedBuffer(seed)
-    var child = master.derive(6) // m/6
+    const seed = crypto.randomBytes(32)
+    const master = ark.HDNode.fromSeedBuffer(seed)
+    const child = master.derive(6) // m/6
 
     // now for the recovery
-    var neuteredMaster = master.neutered()
-    var recovered = recoverParent(neuteredMaster, child)
+    const neuteredMaster = master.neutered()
+    const recovered = recoverParent(neuteredMaster, child)
     assert.strictEqual(recovered.toBase58(), master.toBase58())
   })
 })

--- a/test/ipfs/index.js
+++ b/test/ipfs/index.js
@@ -1,5 +1,7 @@
+/* eslint-disable max-len */
+
+require("should");
 var Buffer = require("buffer/").Buffer;
-var should = require("should");
 var ark = require("../../index.js");
 
 describe("ipfs.js", function () {
@@ -18,20 +20,25 @@ describe("ipfs.js", function () {
     (ipfs).should.have.property("createHashRegistration");
   });
 
-  it("should create transaction with hashid", function () {
-    trs = ipfs.createHashRegistration("QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ/cat.jpg", "secret");
+  it("should create transaction with hashid & deserialise correctly", function () {
+    var trs = ipfs.createHashRegistration("QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ/cat.jpg", "secret");
     (trs).should.be.ok;
-  });
 
-  it("should be deserialised correctly", function () {
     var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
     var keys = Object.keys(deserialisedTx);
-    for(key in keys){
+    for(var key in keys){
       deserialisedTx[keys[key]].should.equal(trs[keys[key]]);
     }
   });
 
   describe("returned transaction", function () {
+    var trs
+
+    before(function () {
+      trs = ipfs.createHashRegistration("QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ/cat.jpg", "secret");
+      (trs).should.be.ok;
+    });
+
     it("should be object", function () {
       (trs).should.be.type("object");
     });

--- a/test/ipfs/index.js
+++ b/test/ipfs/index.js
@@ -1,12 +1,12 @@
 /* eslint-disable max-len */
 
 require("should");
-var Buffer = require("buffer/").Buffer;
-var ark = require("../../index.js");
+const Buffer = require("buffer/").Buffer;
+const ark = require("../../index.js");
 
 describe("ipfs.js", function () {
 
-  var ipfs = ark.ipfs;
+  const ipfs = ark.ipfs;
 
   it("should be ok", function () {
     (ipfs).should.be.ok;
@@ -21,18 +21,18 @@ describe("ipfs.js", function () {
   });
 
   it("should create transaction with hashid & deserialise correctly", function () {
-    var trs = ipfs.createHashRegistration("QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ/cat.jpg", "secret");
+    const trs = ipfs.createHashRegistration("QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ/cat.jpg", "secret");
     (trs).should.be.ok;
 
-    var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
-    var keys = Object.keys(deserialisedTx);
-    for(var key in keys){
+    const deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
+    const keys = Object.keys(deserialisedTx);
+    for(const key in keys){
       deserialisedTx[keys[key]].should.equal(trs[keys[key]]);
     }
   });
 
   describe("returned transaction", function () {
-    var trs
+    let trs
 
     before(function () {
       trs = ipfs.createHashRegistration("QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ/cat.jpg", "secret");
@@ -100,19 +100,19 @@ describe("ipfs.js", function () {
     });
 
     it("should be signed correctly", function () {
-      var result = ark.crypto.verify(trs);
+      const result = ark.crypto.verify(trs);
       (result).should.be.ok;
     });
 
     it("should not be signed correctly now (changed amount)", function () {
       trs.amount = 10000;
-      var result = ark.crypto.verify(trs);
+      const result = ark.crypto.verify(trs);
       (result).should.be.not.ok;
     });
 
     it("should not be signed correctly now (changed vendorField)", function () {
       trs.vendorField = "bouloup";
-      var result = ark.crypto.verify(trs);
+      const result = ark.crypto.verify(trs);
       (result).should.be.not.ok;
     });
   });

--- a/test/multisignature/index.js
+++ b/test/multisignature/index.js
@@ -1,8 +1,8 @@
-var ark = require("../../index.js");
+const ark = require("../../index.js");
 
 describe("multisignature.js", function () {
 
-  var multisignature = ark.multisignature;
+  const multisignature = ark.multisignature;
 
   it("should be ok", function () {
     (multisignature).should.be.ok;
@@ -17,8 +17,8 @@ describe("multisignature.js", function () {
   });
 
   describe("#createMultisignature", function () {
-    var createMultisignature = multisignature.createMultisignature;
-    var sgn = null;
+    const createMultisignature = multisignature.createMultisignature;
+    let sgn = null;
 
     it("should be function", function () {
       (createMultisignature).should.be.type("function");
@@ -39,10 +39,10 @@ describe("multisignature.js", function () {
     });
 
     it("should create multisignature transaction from keys", function () {
-      var secretKey = ark.ECPair.fromSeed("secret");
+      const secretKey = ark.ECPair.fromSeed("secret");
       secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex");
 
-      var secondSecretKey = ark.ECPair.fromSeed("second secret");
+      const secondSecretKey = ark.ECPair.fromSeed("second secret");
       secondSecretKey.publicKey = secondSecretKey.getPublicKeyBuffer().toString("hex");
 
       sgn = createMultisignature(secretKey, secondSecretKey,[
@@ -55,10 +55,10 @@ describe("multisignature.js", function () {
     });
 
     it("should be deserialised correctly", function () {
-      var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(sgn).toString("hex"));
+      const deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(sgn).toString("hex"));
       delete deserialisedTx.vendorFieldHex;
-      var keys = Object.keys(deserialisedTx)
-      for(var key in keys){
+      const keys = Object.keys(deserialisedTx)
+      for(const key in keys){
         if(keys[key] == "asset"){
           deserialisedTx.asset.multisignature.min.should.equal(sgn.asset.multisignature.min);
           deserialisedTx.asset.multisignature.lifetime.should.equal(sgn.asset.multisignature.lifetime);

--- a/test/multisignature/index.js
+++ b/test/multisignature/index.js
@@ -1,5 +1,3 @@
-var Buffer = require("buffer/").Buffer;
-var should = require("should");
 var ark = require("../../index.js");
 
 describe("multisignature.js", function () {
@@ -27,7 +25,15 @@ describe("multisignature.js", function () {
     });
 
     it("should create multisignature transaction", function () {
-      sgn = createMultisignature("secret", "second secret",["03a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933","13a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933","23a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933"], 255, 2);
+      sgn = createMultisignature(
+        "secret",
+        "second secret",
+        [ "03a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933",
+          "13a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933",
+          "23a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933"],
+        255,
+        2
+      );
       (sgn).should.be.ok;
       (sgn).should.be.type("object");
     });
@@ -36,12 +42,12 @@ describe("multisignature.js", function () {
       var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(sgn).toString("hex"));
       delete deserialisedTx.vendorFieldHex;
       var keys = Object.keys(deserialisedTx)
-      for(key in keys){
+      for(var key in keys){
         if(keys[key] == "asset"){
           deserialisedTx.asset.multisignature.min.should.equal(sgn.asset.multisignature.min);
           deserialisedTx.asset.multisignature.lifetime.should.equal(sgn.asset.multisignature.lifetime);
           deserialisedTx.asset.multisignature.keysgroup.length.should.equal(sgn.asset.multisignature.keysgroup.length);
-          console.log(JSON.stringify(deserialisedTx.asset.multisignature.keysgroup));
+          //console.log(JSON.stringify(deserialisedTx.asset.multisignature.keysgroup));
           deserialisedTx.asset.multisignature.keysgroup[0].should.equal(sgn.asset.multisignature.keysgroup[0]);
           deserialisedTx.asset.multisignature.keysgroup[1].should.equal(sgn.asset.multisignature.keysgroup[1]);
           deserialisedTx.asset.multisignature.keysgroup[2].should.equal(sgn.asset.multisignature.keysgroup[2]);

--- a/test/multisignature/index.js
+++ b/test/multisignature/index.js
@@ -45,7 +45,11 @@ describe("multisignature.js", function () {
       var secondSecretKey = ark.ECPair.fromSeed("second secret");
       secondSecretKey.publicKey = secondSecretKey.getPublicKeyBuffer().toString("hex");
 
-      sgn = createMultisignature(secretKey, secondSecretKey,["03a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933","13a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933","23a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933"], 255, 2);
+      sgn = createMultisignature(secretKey, secondSecretKey,[
+        "03a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933",
+        "13a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933",
+        "23a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933"],
+        255, 2);
       (sgn).should.be.ok;
       (sgn).should.be.type("object");
     });

--- a/test/signature/index.js
+++ b/test/signature/index.js
@@ -1,5 +1,5 @@
+require("should");
 var Buffer = require("buffer/").Buffer;
-var should = require("should");
 var ark = require("../../index.js");
 
 describe("signature.js", function () {
@@ -36,7 +36,7 @@ describe("signature.js", function () {
       var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(sgn).toString("hex"));
       delete deserialisedTx.vendorFieldHex;
       var keys = Object.keys(deserialisedTx)
-      for(key in keys){
+      for(var key in keys){
         if(keys[key] == "asset"){
           deserialisedTx.asset.signature.publicKey.should.equal(sgn.asset.signature.publicKey);
         }

--- a/test/signature/index.js
+++ b/test/signature/index.js
@@ -1,10 +1,10 @@
 require("should");
-var Buffer = require("buffer/").Buffer;
-var ark = require("../../index.js");
+const Buffer = require("buffer/").Buffer;
+const ark = require("../../index.js");
 
 describe("signature.js", function () {
 
-  var signature = ark.signature;
+  const signature = ark.signature;
 
   it("should be ok", function () {
     (signature).should.be.ok;
@@ -19,8 +19,8 @@ describe("signature.js", function () {
   });
 
   describe("#createSignature", function () {
-    var createSignature = signature.createSignature;
-    var sgn = null;
+    const createSignature = signature.createSignature;
+    let sgn = null;
 
     it("should be function", function () {
       (createSignature).should.be.type("function");
@@ -33,7 +33,7 @@ describe("signature.js", function () {
     });
 
     it("should create signature transaction", function () {
-      var secretKey = ark.ECPair.fromSeed("secret");
+      const secretKey = ark.ECPair.fromSeed("secret");
       secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex");
 
       sgn = createSignature(secretKey, "second secret");
@@ -42,10 +42,10 @@ describe("signature.js", function () {
     });
 
     it("should be deserialised correctly", function () {
-      var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(sgn).toString("hex"));
+      const deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(sgn).toString("hex"));
       delete deserialisedTx.vendorFieldHex;
-      var keys = Object.keys(deserialisedTx)
-      for(var key in keys){
+      const keys = Object.keys(deserialisedTx)
+      for(const key in keys){
         if(keys[key] == "asset"){
           deserialisedTx.asset.signature.publicKey.should.equal(sgn.asset.signature.publicKey);
         }
@@ -99,7 +99,7 @@ describe("signature.js", function () {
         });
 
         it("should have publicKey in 33 bytes", function () {
-          var publicKey = new Buffer(sgn.asset.signature.publicKey, "hex");
+          const publicKey = new Buffer(sgn.asset.signature.publicKey, "hex");
           (publicKey.length).should.be.equal(33);
         });
       });

--- a/test/slot/index.js
+++ b/test/slot/index.js
@@ -2,7 +2,7 @@ require("should");
 
 describe("slots.js", function () {
 
-  var slots = require("../../lib/time/slots.js");
+  const slots = require("../../lib/time/slots.js");
 
   it("should be ok", function () {
     (slots).should.be.ok;
@@ -13,14 +13,14 @@ describe("slots.js", function () {
   });
 
   it("should have properties", function () {
-    var properties = ["interval", "delegates", "getTime", "getRealTime", "getSlotNumber", "getSlotTime", "getNextSlot", "getLastSlot"];
+    const properties = ["interval", "delegates", "getTime", "getRealTime", "getSlotNumber", "getSlotTime", "getNextSlot", "getLastSlot"];
     properties.forEach(function (property) {
       (slots).should.have.property(property);
     });
   });
 
   describe(".interval", function () {
-    var interval = slots.interval;
+    const interval = slots.interval;
 
     it("should be ok", function () {
       (interval).should.be.ok;
@@ -32,7 +32,7 @@ describe("slots.js", function () {
   });
 
   describe(".delegates", function () {
-    var delegates = slots.delegates;
+    const delegates = slots.delegates;
 
     it("should be ok", function () {
       (delegates).should.be.ok;
@@ -44,7 +44,7 @@ describe("slots.js", function () {
   });
 
   describe("#getTime", function () {
-    var getTime = slots.getTime;
+    const getTime = slots.getTime;
 
     it("should be ok", function () {
       (getTime).should.be.ok;
@@ -55,14 +55,14 @@ describe("slots.js", function () {
     });
 
     it("should return epoch time as number, equal to 10", function () {
-      var d = 1490101210000;
-      var time = getTime(d);
+      const d = 1490101210000;
+      const time = getTime(d);
       (time).should.be.type("number").and.equal(10);
     });
   });
 
   describe("#getRealTime", function () {
-    var getRealTime = slots.getRealTime;
+    const getRealTime = slots.getRealTime;
 
     it("should be ok", function () {
       (getRealTime).should.be.ok;
@@ -73,15 +73,15 @@ describe("slots.js", function () {
     });
 
     it("should return return real time, convert 10 to 1490101210000", function () {
-      var d = 10;
-      var real = getRealTime(d);
+      const d = 10;
+      const real = getRealTime(d);
       (real).should.be.ok;
       (real).should.be.type("number").and.equal(1490101210000);
     });
   });
 
   describe("#getSlotNumber", function () {
-    var getSlotNumber = slots.getSlotNumber;
+    const getSlotNumber = slots.getSlotNumber;
 
     it("should be ok", function () {
       (getSlotNumber).should.be.ok;
@@ -92,13 +92,13 @@ describe("slots.js", function () {
     });
 
     it("should return slot number, equal to 1", function () {
-      var slot = getSlotNumber(10);
+      const slot = getSlotNumber(10);
       (slot).should.be.type("number").and.equal(1);
     });
   });
 
   describe("#getSlotTime", function () {
-    var getSlotTime = slots.getSlotTime;
+    const getSlotTime = slots.getSlotTime;
 
     it("should be ok", function () {
       (getSlotTime).should.be.ok;
@@ -109,14 +109,14 @@ describe("slots.js", function () {
     });
 
     it("should return slot time number, equal to ", function () {
-      var slotTime = getSlotTime(19614);
+      const slotTime = getSlotTime(19614);
       (slotTime).should.be.ok;
       (slotTime).should.be.type("number").and.equal(156912);
     });
   });
 
   describe("#getNextSlot", function () {
-    var getNextSlot = slots.getNextSlot;
+    const getNextSlot = slots.getNextSlot;
 
     it("should be ok", function () {
       (getNextSlot).should.be.ok;
@@ -127,14 +127,14 @@ describe("slots.js", function () {
     });
 
     it("should return next slot number", function () {
-      var nextSlot = getNextSlot();
+      const nextSlot = getNextSlot();
       (nextSlot).should.be.ok;
       (nextSlot).should.be.type("number").and.not.NaN;
     });
   });
 
   describe("#getLastSlot", function () {
-    var getLastSlot = slots.getLastSlot;
+    const getLastSlot = slots.getLastSlot;
 
     it("should be ok", function () {
       (getLastSlot).should.be.ok;
@@ -145,7 +145,7 @@ describe("slots.js", function () {
     });
 
     it("should return last slot number", function () {
-      var lastSlot = getLastSlot(slots.getNextSlot());
+      const lastSlot = getLastSlot(slots.getNextSlot());
       (lastSlot).should.be.ok;
       (lastSlot).should.be.type("number").and.not.NaN;
     });

--- a/test/slot/index.js
+++ b/test/slot/index.js
@@ -1,6 +1,4 @@
-var Buffer = require("buffer/").Buffer;
-var should = require("should");
-var ark = require("../../index.js");
+require("should");
 
 describe("slots.js", function () {
 

--- a/test/transaction/index.js
+++ b/test/transaction/index.js
@@ -1,9 +1,9 @@
-var Buffer = require("buffer/").Buffer;
-var ark = require("../../index.js");
+const Buffer = require("buffer/").Buffer;
+const ark = require("../../index.js");
 
 describe("transaction.js", function () {
 
-  var transaction = ark.transaction;
+  const transaction = ark.transaction;
 
   it("should be object", function () {
     (transaction).should.be.type("object");
@@ -14,8 +14,8 @@ describe("transaction.js", function () {
   })
 
   describe("#createTransaction", function () {
-    var createTransaction = transaction.createTransaction;
-    var trs = null;
+    const createTransaction = transaction.createTransaction;
+    let trs = null;
 
     it("should be a function", function () {
       (createTransaction).should.be.type("function");
@@ -27,7 +27,7 @@ describe("transaction.js", function () {
     });
 
     it("should create transaction without second signature from keys", function () {
-      var secretKey = ark.ECPair.fromSeed("secret");
+      const secretKey = ark.ECPair.fromSeed("secret");
       secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex");
 
       trs = createTransaction("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff", 1000, null, secretKey);
@@ -40,8 +40,8 @@ describe("transaction.js", function () {
     });
 
     it("should fail if transaction with vendorField length > 64", function () {
-      var vf="z";
-      for(var i=0;i<6;i++){
+      let vf="z";
+      for(let i=0;i<6;i++){
         vf=vf+vf;
       }
       vf=vf+"z";
@@ -51,8 +51,8 @@ describe("transaction.js", function () {
     });
 
     it("should be ok if transaction with vendorField length = 64", function () {
-      var vf="z";
-      for(var i=0;i<6;i++){
+      let vf="z";
+      for(let i=0;i<6;i++){
         vf=vf+vf;
       }
       trs = createTransaction("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff", 1000, vf, "secret");
@@ -117,16 +117,16 @@ describe("transaction.js", function () {
       });
 
       it("should be signed correctly", function () {
-        var result = ark.crypto.verify(trs);
+        const result = ark.crypto.verify(trs);
         result.should.equal(true);
       });
 
       it("should be deserialised correctly", function () {
-        var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
+        const deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
         deserialisedTx.vendorField = new Buffer(deserialisedTx.vendorFieldHex, "hex").toString("utf8")
         delete deserialisedTx.vendorFieldHex;
-        var keys = Object.keys(deserialisedTx)
-        for(var key in keys){
+        const keys = Object.keys(deserialisedTx)
+        for(const key in keys){
           if(keys[key] != "vendorFieldHex"){
             deserialisedTx[keys[key]].should.equal(trs[keys[key]]);
           }
@@ -136,7 +136,7 @@ describe("transaction.js", function () {
 
       it("should not be signed correctly now", function () {
         trs.amount = 10000;
-        var result = ark.crypto.verify(trs);
+        const result = ark.crypto.verify(trs);
         result.should.equal(false);
       });
     });
@@ -145,14 +145,14 @@ describe("transaction.js", function () {
   describe("createTransaction and try to tamper signature", function(){
 
     it("should not validate overflown signatures", function(){
-      var BigInteger = require('bigi')
-      var bip66 = require('bip66')
+      const BigInteger = require('bigi')
+      const bip66 = require('bip66')
 
       // custom bip66 encode for hacking away signature
       function BIP66_encode (r, s) {
-        var lenR = r.length;
-        var lenS = s.length;
-        var signature = new Buffer(6 + lenR + lenS);
+        const lenR = r.length;
+        const lenS = s.length;
+        const signature = new Buffer(6 + lenR + lenS);
 
         // 0x30 [total-length] 0x02 [R-length] [R] 0x02 [S-length] [S]
         signature[0] = 0x30;
@@ -168,13 +168,13 @@ describe("transaction.js", function () {
       }
 
       // The transaction to replay
-      var old_transaction = ark.transaction.createTransaction('AacRfTLtxAkR3Mind1XdPCddj1uDkHtwzD', 1, null, 'randomstring');
+      const old_transaction = ark.transaction.createTransaction('AacRfTLtxAkR3Mind1XdPCddj1uDkHtwzD', 1, null, 'randomstring');
 
       // Decode signature
-      var decode = bip66.decode(Buffer(old_transaction.signature, "hex"));
+      const decode = bip66.decode(Buffer(old_transaction.signature, "hex"));
 
-      var r = BigInteger.fromDERInteger(decode.r);
-      var s = BigInteger.fromDERInteger(decode.s);
+      let r = BigInteger.fromDERInteger(decode.r);
+      const s = BigInteger.fromDERInteger(decode.s);
 
       // Transform the signature
       /*
@@ -183,11 +183,11 @@ describe("transaction.js", function () {
       r = r + result
       */
 
-      var result = BigInteger.fromBuffer(Buffer(r.toBuffer(r.toDERInteger().length).toString('hex') + '06', 'hex'));
+      let result = BigInteger.fromBuffer(Buffer(r.toBuffer(r.toDERInteger().length).toString('hex') + '06', 'hex'));
       result = result.subtract(r);
       r = r.add(result);
 
-      var new_signature = BIP66_encode(r.toBuffer(r.toDERInteger().length), s.toBuffer(s.toDERInteger().length)).toString('hex');
+      const new_signature = BIP66_encode(r.toBuffer(r.toDERInteger().length), s.toBuffer(s.toDERInteger().length)).toString('hex');
       //
       // console.log("OLD TRANSACTION : ");
       // console.log("TXID " + ark.crypto.getId(old_transaction));
@@ -210,10 +210,10 @@ describe("transaction.js", function () {
   });
 
   describe("#createTransaction with second secret", function () {
-    var createTransaction = transaction.createTransaction;
-    var trs = null;
-    var secondSecret = "second secret";
-    var keys = ark.crypto.getKeys(secondSecret);
+    const createTransaction = transaction.createTransaction;
+    let trs = null;
+    const secondSecret = "second secret";
+    const keys = ark.crypto.getKeys(secondSecret);
 
     it("should be a function", function () {
       (createTransaction).should.be.type("function");
@@ -303,34 +303,34 @@ describe("transaction.js", function () {
       });
 
       it("should be deserialised correctly", function () {
-        var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
+        const deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
         delete deserialisedTx.vendorFieldHex;
-        var keys = Object.keys(deserialisedTx)
-        for(var key in keys){
+        const keys = Object.keys(deserialisedTx)
+        for(const key in keys){
           deserialisedTx[keys[key]].should.equal(trs[keys[key]]);
         }
 
       });
 
       it("should be signed correctly", function () {
-        var result = ark.crypto.verify(trs);
+        const result = ark.crypto.verify(trs);
         (result).should.equal(true);
       });
 
       it("should be second signed correctly", function () {
-        var result = ark.crypto.verifySecondSignature(trs, keys.publicKey);
+        const result = ark.crypto.verifySecondSignature(trs, keys.publicKey);
         (result).should.equal(true);
       });
 
       it("should not be signed correctly now", function () {
         trs.amount = 10000;
-        var result = ark.crypto.verify(trs);
+        const result = ark.crypto.verify(trs);
         (result).should.equal(false);
       });
 
       it("should not be second signed correctly now", function () {
         trs.amount = 10000;
-        var result = ark.crypto.verifySecondSignature(trs, keys.publicKey);
+        const result = ark.crypto.verifySecondSignature(trs, keys.publicKey);
         (result).should.equal(false);
       });
     });

--- a/test/transaction/index.js
+++ b/test/transaction/index.js
@@ -1,5 +1,4 @@
 var Buffer = require("buffer/").Buffer;
-var should = require("should");
 var ark = require("../../index.js");
 
 describe("transaction.js", function () {
@@ -34,7 +33,7 @@ describe("transaction.js", function () {
 
     it("should fail if transaction with vendorField length > 64", function () {
       var vf="z";
-      for(i=0;i<6;i++){
+      for(var i=0;i<6;i++){
         vf=vf+vf;
       }
       vf=vf+"z";
@@ -45,7 +44,7 @@ describe("transaction.js", function () {
 
     it("should be ok if transaction with vendorField length = 64", function () {
       var vf="z";
-      for(i=0;i<6;i++){
+      for(var i=0;i<6;i++){
         vf=vf+vf;
       }
       trs = createTransaction("AJWRd23HNEhPLkK1ymMnwnDBX2a7QBZqff", 1000, vf, "secret");
@@ -119,7 +118,7 @@ describe("transaction.js", function () {
         deserialisedTx.vendorField = new Buffer(deserialisedTx.vendorFieldHex, "hex").toString("utf8")
         delete deserialisedTx.vendorFieldHex;
         var keys = Object.keys(deserialisedTx)
-        for(key in keys){
+        for(var key in keys){
           if(keys[key] != "vendorFieldHex"){
             deserialisedTx[keys[key]].should.equal(trs[keys[key]]);
           }
@@ -176,11 +175,11 @@ describe("transaction.js", function () {
       r = r + result
       */
 
-      result = BigInteger.fromBuffer(Buffer(r.toBuffer(r.toDERInteger().length).toString('hex') + '06', 'hex'));
+      var result = BigInteger.fromBuffer(Buffer(r.toBuffer(r.toDERInteger().length).toString('hex') + '06', 'hex'));
       result = result.subtract(r);
       r = r.add(result);
 
-      new_signature = BIP66_encode(r.toBuffer(r.toDERInteger().length), s.toBuffer(s.toDERInteger().length)).toString('hex');
+      var new_signature = BIP66_encode(r.toBuffer(r.toDERInteger().length), s.toBuffer(s.toDERInteger().length)).toString('hex');
       //
       // console.log("OLD TRANSACTION : ");
       // console.log("TXID " + ark.crypto.getId(old_transaction));
@@ -299,7 +298,7 @@ describe("transaction.js", function () {
         var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
         delete deserialisedTx.vendorFieldHex;
         var keys = Object.keys(deserialisedTx)
-        for(key in keys){
+        for(var key in keys){
           deserialisedTx[keys[key]].should.equal(trs[keys[key]]);
         }
 

--- a/test/vote/index.js
+++ b/test/vote/index.js
@@ -1,12 +1,12 @@
 require("should");
-var Buffer = require("buffer/").Buffer;
-var ark = require("../../index.js");
+const Buffer = require("buffer/").Buffer;
+const ark = require("../../index.js");
 
-var NETWORKS = require('../../lib/networks');
+const NETWORKS = require('../../lib/networks');
 
 describe("vote.js", function () {
 
-  var vote = ark.vote;
+  const vote = ark.vote;
 
   it("should be ok", function () {
     (vote).should.be.ok;
@@ -21,10 +21,10 @@ describe("vote.js", function () {
   });
 
   describe("#createVote", function () {
-    var createVote = vote.createVote,
-      vt = null,
-      publicKey = ark.crypto.getKeys("secret").publicKey,
-      publicKeys = ["+" + publicKey];
+    const createVote = vote.createVote
+    const publicKey = ark.crypto.getKeys("secret").publicKey
+    const publicKeys = ["+" + publicKey]
+    let vt = null
 
     it("should be ok", function () {
       (createVote).should.be.ok;
@@ -39,30 +39,30 @@ describe("vote.js", function () {
     });
 
     it("should create vote from ecpair", function () {
-      var secretKey = ark.ECPair.fromSeed("secret");
+      const secretKey = ark.ECPair.fromSeed("secret");
       secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex");
 
-      var secondSecretKey = ark.ECPair.fromSeed("second secret");
+      const secondSecretKey = ark.ECPair.fromSeed("second secret");
       secondSecretKey.publicKey = secondSecretKey.getPublicKeyBuffer().toString("hex");
 
       vt = createVote(secretKey, publicKeys, secondSecretKey);
     });
 
     it("should create vote from wif", function () {
-      var secretKey = ark.ECPair.fromWIF("SB3iDxYmKgjkhfDZSKgLaBrp3Ynzd3yd3ZZF2ujVBK7vLpv6hWKK", NETWORKS.ark);
+      const secretKey = ark.ECPair.fromWIF("SB3iDxYmKgjkhfDZSKgLaBrp3Ynzd3yd3ZZF2ujVBK7vLpv6hWKK", NETWORKS.ark);
       secretKey.publicKey = secretKey.getPublicKeyBuffer().toString("hex");
 
-      var tx = createVote(secretKey, publicKeys);
+      const tx = createVote(secretKey, publicKeys);
       (tx).should.be.ok;
       (tx).should.be.type("object");
       (tx).should.have.property("recipientId").and.be.type("string").and.be.equal("AL9uJWA5nd6RWn8VSUzGN7spWeZGHeudg9");
     });
 
     it("should be deserialised correctly", function () {
-      var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(vt).toString("hex"));
+      const deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(vt).toString("hex"));
       delete deserialisedTx.vendorFieldHex;
-      var keys = Object.keys(deserialisedTx)
-      for(var key in keys){
+      const keys = Object.keys(deserialisedTx)
+      for(const key in keys){
         if(keys[key] == "asset"){
           deserialisedTx.asset.votes[0].should.equal(vt.asset.votes[0]);
         }
@@ -135,24 +135,24 @@ describe("vote.js", function () {
       });
 
       it("should be signed correctly", function () {
-        var result = ark.crypto.verify(vt);
+        const result = ark.crypto.verify(vt);
         (result).should.be.ok;
       });
 
       it("should be second signed correctly", function () {
-        var result = ark.crypto.verifySecondSignature(vt, ark.crypto.getKeys("second secret").publicKey);
+        const result = ark.crypto.verifySecondSignature(vt, ark.crypto.getKeys("second secret").publicKey);
         (result).should.be.ok;
       });
 
       it("should not be signed correctly now", function () {
         vt.amount = 100;
-        var result = ark.crypto.verify(vt);
+        const result = ark.crypto.verify(vt);
         (result).should.be.not.ok;
       });
 
       it("should not be second signed correctly now", function () {
         vt.amount = 100;
-        var result = ark.crypto.verifySecondSignature(vt, ark.crypto.getKeys("second secret").publicKey);
+        const result = ark.crypto.verifySecondSignature(vt, ark.crypto.getKeys("second secret").publicKey);
         (result).should.be.not.ok;
       });
 
@@ -192,7 +192,7 @@ describe("vote.js", function () {
         });
 
         it("should be equal to sender public key", function () {
-          var v = vt.asset.votes[0];
+          const v = vt.asset.votes[0];
           (v.substring(1, v.length)).should.be.equal(publicKey);
         });
       })

--- a/test/vote/index.js
+++ b/test/vote/index.js
@@ -1,5 +1,5 @@
+require("should");
 var Buffer = require("buffer/").Buffer;
-var should = require("should");
 var ark = require("../../index.js");
 
 describe("vote.js", function () {
@@ -40,7 +40,7 @@ describe("vote.js", function () {
       var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(vt).toString("hex"));
       delete deserialisedTx.vendorFieldHex;
       var keys = Object.keys(deserialisedTx)
-      for(key in keys){
+      for(var key in keys){
         if(keys[key] == "asset"){
           deserialisedTx.asset.votes[0].should.equal(vt.asset.votes[0]);
         }


### PR DESCRIPTION
Convert `var` into `let` & `const`. Some local-scoped `var`s in lib/v2 were rewritten as block-scoped lets. Requires PR #15.