### PR TITLE
Remove Public Key Reference from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Returning:
 ```js
 {
   publicKey: "5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09",
-  privateKey: "2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a2…44491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Returning:
 
 ```js
 {
-  publicKey: "5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09",
+  publicKey: "5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09"
 }
 ```
 


### PR DESCRIPTION
This actually returns a blank string for privateKey which made me think it wasn't working correctly. Private Key can be obtained using `keys.d.toBuffer().toString('hex')`. I thought about including this in the README but as far as I can tell its not really needed.