### PR TITLE
Safe buffers

### DIFF
--- a/lib/ecdsa.js
+++ b/lib/ecdsa.js
@@ -1,5 +1,6 @@
 /** @module ecdsa */
 
+var Buffer = require('safe-buffer').Buffer
 var createHmac = require('create-hmac')
 var typeforce = require('typeforce')
 var types = require('./types')
@@ -7,8 +8,8 @@ var types = require('./types')
 var BigInteger = require('bigi')
 var ECSignature = require('./ecsignature')
 
-var ZERO = new Buffer([0])
-var ONE = new Buffer([1])
+var ZERO = Buffer.from([0])
+var ONE = Buffer.from([1])
 
 var ecurve = require('ecurve')
 var secp256k1 = ecurve.getCurveByName('secp256k1')
@@ -29,15 +30,14 @@ function deterministicGenerateK (hash, x, checkSig) {
     types.Function
   ), arguments)
 
-  var k = new Buffer(32)
-  var v = new Buffer(32)
+  var v, k
 
   // Step A, ignored as hash already provided
   // Step B
-  v.fill(1)
+  v = Buffer.alloc(32, 1)
 
   // Step C
-  k.fill(0)
+  k = Buffer.alloc(32, 0)
 
   // Step D
   k = createHmac('sha256', k)

--- a/lib/ecpair.js
+++ b/lib/ecpair.js
@@ -1,5 +1,6 @@
 var base58check = require('bs58check')
 var bcrypto = require('./crypto')
+var Buffer = require('safe-buffer').Buffer
 var ecdsa = require('./ecdsa')
 var ECSignature = require('./ecsignature')
 var randomBytes = require('randombytes')
@@ -137,7 +138,7 @@ ECPair.makeRandom = function (options) {
  * @returns {ECPair}
  */
 ECPair.fromSeed = function(seed, options) {
-  var hash = bcrypto.sha256(new Buffer(seed,"utf-8"))
+  var hash = bcrypto.sha256(Buffer.from(seed,"utf-8"))
   var d = BigInteger.fromBuffer(hash)
   if(d.signum() <= 0 || d.compareTo(secp256k1.n) >= 0){
     throw new Error("seed cannot resolve to a compatible private key")
@@ -151,7 +152,7 @@ ECPair.fromSeed = function(seed, options) {
  * @returns {string}
  */
 ECPair.prototype.getAddress = function () {
-  var payload = new Buffer(21)
+  var payload = Buffer.alloc(21)
   var hash = bcrypto.ripemd160(this.getPublicKeyBuffer())
   var version = this.getNetwork().pubKeyHash
   payload.writeUInt8(version, 0)

--- a/lib/ecsignature.js
+++ b/lib/ecsignature.js
@@ -1,4 +1,5 @@
 var bip66 = require('bip66')
+var Buffer = require('safe-buffer').Buffer
 var typeforce = require('typeforce')
 var types = require('./types')
 
@@ -49,7 +50,7 @@ ECSignature.parseNativeSecp256k1 = function (native) {
  * @returns {Buffer}
  */
 ECSignature.prototype.toNativeSecp256k1 = function () {
-  var buffer = new Buffer(64)
+  var buffer = Buffer.alloc(64)
   if(this.r.toBuffer().length > 32 || this.s.toBuffer().length > 32){
     return buffer;
   }
@@ -124,7 +125,7 @@ ECSignature.prototype.toCompact = function (i, compressed) {
 
   i += 27
 
-  var buffer = new Buffer(65)
+  var buffer = Buffer.allocUnsafe(65)
   buffer.writeUInt8(i, 0)
 
   this.r.toBuffer(32).copy(buffer, 1)
@@ -137,8 +138,8 @@ ECSignature.prototype.toCompact = function (i, compressed) {
  * @return {Buffer}
  */
 ECSignature.prototype.toDER = function () {
-  var r = new Buffer(this.r.toDERInteger())
-  var s = new Buffer(this.s.toDERInteger())
+  var r = Buffer.from(this.r.toDERInteger())
+  var s = Buffer.from(this.s.toDERInteger())
 
   return bip66.encode(r, s)
 }
@@ -151,7 +152,7 @@ ECSignature.prototype.toScriptSignature = function (hashType) {
   var hashTypeMod = hashType & ~0x80
   if (hashTypeMod <= 0 || hashTypeMod >= 4) throw new Error('Invalid hashType ' + hashType)
 
-  var hashTypeBuffer = new Buffer(1)
+  var hashTypeBuffer = Buffer.alloc(1)
   hashTypeBuffer.writeUInt8(hashType, 0)
 
   return Buffer.concat([this.toDER(), hashTypeBuffer])

--- a/lib/hdnode.js
+++ b/lib/hdnode.js
@@ -1,5 +1,6 @@
 var base58check = require('bs58check')
 var bcrypto = require('./crypto')
+var Buffer = require('safe-buffer').Buffer
 var createHmac = require('create-hmac')
 var typeforce = require('typeforce')
 var types = require('./types')
@@ -30,7 +31,7 @@ function HDNode (keyPair, chainCode) {
 
 HDNode.HIGHEST_BIT = 0x80000000
 HDNode.LENGTH = 78
-HDNode.MASTER_SECRET = new Buffer('Bitcoin seed')
+HDNode.MASTER_SECRET = Buffer.from('Bitcoin seed')
 
 /**
  * @param {string|Buffer} seed
@@ -62,7 +63,7 @@ HDNode.fromSeedBuffer = function (seed, network) {
  * @returns {HDNode}
  */
 HDNode.fromSeedHex = function (hex, network) {
-  return HDNode.fromSeedBuffer(new Buffer(hex, 'hex'), network)
+  return HDNode.fromSeedBuffer(Buffer.from(hex, 'hex'), network)
 }
 
 /**
@@ -213,7 +214,7 @@ HDNode.prototype.toBase58 = function () {
   // Version
   var network = this.keyPair.network
   var version = (!this.isNeutered()) ? network.bip32.private : network.bip32.public
-  var buffer = new Buffer(78)
+  var buffer = Buffer.alloc(78)
 
   // 4 bytes: version bytes
   buffer.writeUInt32BE(version, 0)
@@ -256,7 +257,7 @@ HDNode.prototype.derive = function (index) {
   typeforce(types.UInt32, index)
 
   var isHardened = index >= HDNode.HIGHEST_BIT
-  var data = new Buffer(37)
+  var data = Buffer.alloc(37)
 
   // Hardened child
   if (isHardened) {

--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -1,5 +1,6 @@
 /** @module crypto */
 
+var Buffer = require('safe-buffer').Buffer
 var crypto = require("crypto");
 var crypto_utils = require("../crypto.js");
 var ECPair = require("../ecpair.js");
@@ -37,7 +38,7 @@ function isECPair(obj) {
  */
 function getSignatureBytes(signature) {
 	var bb = new ByteBuffer(33, true);
-	var publicKeyBuffer = new Buffer(signature.publicKey, "hex");
+	var publicKeyBuffer = Buffer.from(signature.publicKey, "hex");
 
 	for (var i = 0; i < publicKeyBuffer.length; i++) {
 		bb.writeByte(publicKeyBuffer[i]);
@@ -65,19 +66,19 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 			break;
 
 		case 2: // Delegate
-			assetBytes = new Buffer(transaction.asset.delegate.username, "utf8");
+			assetBytes = Buffer.from(transaction.asset.delegate.username, "utf8");
 			assetSize = assetBytes.length;
 			break;
 
 		case 3: // Vote
 			if (transaction.asset.votes !== null) {
-				assetBytes = new Buffer(transaction.asset.votes.join(""), "utf8");
+				assetBytes = Buffer.from(transaction.asset.votes.join(""), "utf8");
 				assetSize = assetBytes.length;
 			}
 			break;
 
 		case 4: // Multi-Signature
-			var keysgroupBuffer = new Buffer(transaction.asset.multisignature.keysgroup.join(""), "utf8");
+			var keysgroupBuffer = Buffer.from(transaction.asset.multisignature.keysgroup.join(""), "utf8");
 			var bb = new ByteBuffer(1 + 1 + keysgroupBuffer.length, true);
 
 			bb.writeByte(transaction.asset.multisignature.min);
@@ -99,7 +100,7 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 	bb.writeByte(transaction.type);
 	bb.writeInt(transaction.timestamp);
 
-	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
+	var senderPublicKeyBuffer = Buffer.from(transaction.senderPublicKey, "hex");
 	for (var i = 0; i < senderPublicKeyBuffer.length; i++) {
 		bb.writeByte(senderPublicKeyBuffer[i]);
 	}
@@ -116,7 +117,7 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 	}
 
 	if(transaction.vendorFieldHex){
-		var vf = new Buffer(transaction.vendorFieldHex,"hex");
+		var vf = Buffer.from(transaction.vendorFieldHex,"hex");
 		var fillstart=vf.length;
 		for (i = 0; i < fillstart; i++) {
 			bb.writeByte(vf[i]);
@@ -126,7 +127,7 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 		}
 	}
 	else if (transaction.vendorField) {
-		var vf = new Buffer(transaction.vendorField);
+		var vf = Buffer.from(transaction.vendorField);
 		var fillstart=vf.length;
 		for (i = 0; i < fillstart; i++) {
 			bb.writeByte(vf[i]);
@@ -151,14 +152,14 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 	}
 
 	if (!skipSignature && transaction.signature) {
-		var signatureBuffer = new Buffer(transaction.signature, "hex");
+		var signatureBuffer = Buffer.from(transaction.signature, "hex");
 		for (var i = 0; i < signatureBuffer.length; i++) {
 			bb.writeByte(signatureBuffer[i]);
 		}
 	}
 
 	if (!skipSecondSignature && transaction.signSignature) {
-		var signSignatureBuffer = new Buffer(transaction.signSignature, "hex");
+		var signSignatureBuffer = Buffer.from(transaction.signSignature, "hex");
 		for (var i = 0; i < signSignatureBuffer.length; i++) {
 			bb.writeByte(signSignatureBuffer[i]);
 		}
@@ -172,7 +173,7 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 		buffer[i] = arrayBuffer[i];
 	}
 
-	return new Buffer(buffer);
+	return Buffer.from(buffer);
 }
 
 /**
@@ -182,7 +183,7 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
  */
 function fromBytes(hexString){
 	var tx={};
-	var buf = new Buffer(hexString, "hex");
+	var buf = Buffer.from(hexString, "hex");
 	tx.type = buf.readInt8(0) & 0xff;
 	tx.timestamp = buf.readUInt32LE(1);
 	tx.senderPublicKey = hexString.substring(10,10+33*2);
@@ -209,7 +210,7 @@ function fromBytes(hexString){
 
 		tx.asset = {
 			delegate: {
-				username: new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex").toString("utf8")
+				username: Buffer.from(hexString.substring(76+42+128+32,hexString.length-offset),"hex").toString("utf8")
 			}
 		};
 	}
@@ -217,13 +218,13 @@ function fromBytes(hexString){
 		// Impossible to assess size of vote asset, trying to grab signature and derive vote asset
 		var offset = findAndParseSignatures(hexString, tx);
 		tx.asset = {
-			votes: new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex").toString("utf8").split(",")
+			votes: Buffer.from(hexString.substring(76+42+128+32,hexString.length-offset),"hex").toString("utf8").split(",")
 		};
 	}
 	else if(tx.type == 4){ // multisignature creation
 		delete tx.recipientId;
 		var offset = findAndParseSignatures(hexString, tx);
-		var buffer = new Buffer(hexString.substring(76+42+128+32,hexString.length-offset),"hex")
+		var buffer = Buffer.from(hexString.substring(76+42+128+32,hexString.length-offset),"hex")
 		tx.asset = {
 			multisignature: {}
 		}
@@ -252,7 +253,7 @@ function fromBytes(hexString){
  * @returns {number}
  */
 function findAndParseSignatures(hexString, tx){
-	var signature1 = new Buffer(hexString.substring(hexString.length-146), "hex");
+	var signature1 = Buffer.from(hexString.substring(hexString.length-146), "hex");
 	var signature2 = null;
 	var found      = false;
 	var offset     = 0;
@@ -274,7 +275,7 @@ function findAndParseSignatures(hexString, tx){
 	else {
 		found = false;
 		offset = signature1.length*2;
-		var signature2 = new Buffer(hexString.substring(hexString.length-offset-146, hexString.length-offset), "hex");
+		var signature2 = Buffer.from(hexString.substring(hexString.length-offset-146, hexString.length-offset), "hex");
 		while(!found && signature2.length > 8){
 			if(signature2[0] != 0x30){
 				signature2 = signature2.slice(1);
@@ -406,8 +407,8 @@ function verify(transaction, network) {
 
 	var hash = getHash(transaction, true, true);
 
-	var signatureBuffer = new Buffer(transaction.signature, "hex");
-	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
+	var signatureBuffer = Buffer.from(transaction.signature, "hex");
+	var senderPublicKeyBuffer = Buffer.from(transaction.senderPublicKey, "hex");
 	var ecpair = ECPair.fromPublicKeyBuffer(senderPublicKeyBuffer, network);
 	var ecsignature = ECSignature.fromDER(signatureBuffer);
 	var res = ecpair.verify(hash, ecsignature);
@@ -426,8 +427,8 @@ function verifySecondSignature(transaction, publicKey, network) {
 
 	var hash = getHash(transaction, false, true);
 
-	var signSignatureBuffer = new Buffer(transaction.signSignature, "hex");
-	var publicKeyBuffer = new Buffer(publicKey, "hex");
+	var signSignatureBuffer = Buffer.from(transaction.signSignature, "hex");
+	var publicKeyBuffer = Buffer.from(publicKey, "hex");
 	var ecpair = ECPair.fromPublicKeyBuffer(publicKeyBuffer, network);
 	var ecsignature = ECSignature.fromDER(signSignatureBuffer);
 	var res = ecpair.verify(hash, ecsignature);
@@ -460,9 +461,9 @@ function getAddress(publicKey, version){
 	if(!version){
 		version = networkVersion;
 	}
-	var buffer = crypto_utils.ripemd160(new Buffer(publicKey,'hex'));
+	var buffer = crypto_utils.ripemd160(Buffer.from(publicKey,'hex'));
 
-	var payload = new Buffer(21);
+	var payload = Buffer.alloc(21);
 	payload.writeUInt8(version, 0);
 	buffer.copy(payload, 1);
 

--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -33,15 +33,8 @@ function isECPair(obj) {
  * @returns {Uint8Array}
  */
 function getSignatureBytes(signature) {
-	var bb = new ByteBuffer(33, true);
-	var publicKeyBuffer = Buffer.from(signature.publicKey, "hex");
-
-	for (var i = 0; i < publicKeyBuffer.length; i++) {
-		bb.writeByte(publicKeyBuffer[i]);
-	}
-
-	bb.flip();
-	return new Uint8Array(bb.toArrayBuffer());
+	var buffer = Buffer.alloc(33, signature.publicKey, "hex")
+	return new Uint8Array(buffer)
 }
 
 /**
@@ -52,24 +45,20 @@ function getSignatureBytes(signature) {
  * @returns {Buffer}
  */
 function getBytes(transaction, skipSignature, skipSecondSignature) {
-	var assetSize = 0,
-		assetBytes = null;
+	var assetBytes = null;
 
 	switch (transaction.type) {
 		case 1: // Signature
 			assetBytes = getSignatureBytes(transaction.asset.signature);
-			assetSize = assetBytes.length;
 			break;
 
 		case 2: // Delegate
 			assetBytes = Buffer.from(transaction.asset.delegate.username, "utf8");
-			assetSize = assetBytes.length;
 			break;
 
 		case 3: // Vote
 			if (transaction.asset.votes !== null) {
 				assetBytes = Buffer.from(transaction.asset.votes.join(""), "utf8");
-				assetSize = assetBytes.length;
 			}
 			break;
 
@@ -87,89 +76,56 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 			bb.flip();
 
 			assetBytes = bb.toBuffer();
-			assetSize  = assetBytes.length;
 			break;
 
 	}
 
-	var bb = new ByteBuffer(1 + 4 + 32 + 8 + 8 + 21 + 64 + 64 + 64 + assetSize, true);
+	var assetLength = assetBytes !== null ? assetBytes.length : 0
+	var bb = new ByteBuffer(1 + 4 + 32 + 8 + 8 + 21 + 64 + 64 + 64 + assetLength, true);
 	bb.writeByte(transaction.type);
 	bb.writeInt(transaction.timestamp);
 
-	var senderPublicKeyBuffer = Buffer.from(transaction.senderPublicKey, "hex");
-	for (var i = 0; i < senderPublicKeyBuffer.length; i++) {
-		bb.writeByte(senderPublicKeyBuffer[i]);
-	}
+	bb.append(transaction.senderPublicKey, "hex")
 
 	if (transaction.recipientId) {
 		var recipient = bs58check.decode(transaction.recipientId);
-		for (var i = 0; i < recipient.length; i++) {
-			bb.writeByte(recipient[i]);
-		}
+		console.assert(recipient.length === 21)
+		bb.append(recipient)
 	} else {
-		for (var i = 0; i < 21; i++) {
-			bb.writeByte(0);
-		}
+		bb.append(Buffer.alloc(21, 0))
 	}
 
 	if(transaction.vendorFieldHex){
-		var vf = Buffer.from(transaction.vendorFieldHex,"hex");
-		var fillstart=vf.length;
-		for (i = 0; i < fillstart; i++) {
-			bb.writeByte(vf[i]);
-		}
-		for (i = fillstart; i < 64; i++) {
-			bb.writeByte(0);
-		}
+		var vf = Buffer.alloc(64, transaction.vendorFieldHex, "hex")
+		bb.append(vf)
 	}
 	else if (transaction.vendorField) {
-		var vf = Buffer.from(transaction.vendorField);
-		var fillstart=vf.length;
-		for (i = 0; i < fillstart; i++) {
-			bb.writeByte(vf[i]);
-		}
-		for (i = fillstart; i < 64; i++) {
-			bb.writeByte(0);
-		}
+		var vf = Buffer.alloc(64, transaction.vendorField, "utf8")
+		bb.append(vf)
 	} else {
-		for (i = 0; i < 64; i++) {
-			bb.writeByte(0);
-		}
+		bb.append(Buffer.alloc(64, 0))
 	}
 
 	bb.writeLong(transaction.amount);
 
 	bb.writeLong(transaction.fee);
 
-	if (assetSize > 0) {
-		for (var i = 0; i < assetSize; i++) {
-			bb.writeByte(assetBytes[i]);
-		}
+	if (assetLength > 0) {
+		bb.append(assetBytes)
 	}
 
 	if (!skipSignature && transaction.signature) {
 		var signatureBuffer = Buffer.from(transaction.signature, "hex");
-		for (var i = 0; i < signatureBuffer.length; i++) {
-			bb.writeByte(signatureBuffer[i]);
-		}
+		bb.append(signatureBuffer)
 	}
 
 	if (!skipSecondSignature && transaction.signSignature) {
 		var signSignatureBuffer = Buffer.from(transaction.signSignature, "hex");
-		for (var i = 0; i < signSignatureBuffer.length; i++) {
-			bb.writeByte(signSignatureBuffer[i]);
-		}
+		bb.append(signSignatureBuffer)
 	}
 
-	bb.flip();
-	var arrayBuffer = new Uint8Array(bb.toArrayBuffer());
-	var buffer = [];
-
-	for (var i = 0; i < arrayBuffer.length; i++) {
-		buffer[i] = arrayBuffer[i];
-	}
-
-	return Buffer.from(buffer);
+	bb.flip()
+	return bb.toBuffer()
 }
 
 /**
@@ -238,7 +194,6 @@ function fromBytes(hexString){
 		delete tx.recipientId;
 		parseSignatures(hexString, tx, 76+42+128+32);
 	}
-	console.log(tx);
 	return tx;
 }
 
@@ -457,9 +412,10 @@ function getAddress(publicKey, version){
 	if(!version){
 		version = networkVersion;
 	}
-	var buffer = crypto_utils.ripemd160(Buffer.from(publicKey,'hex'));
 
 	var payload = Buffer.alloc(21);
+	var buffer = crypto_utils.ripemd160(Buffer.from(publicKey,'hex'));
+
 	payload.writeUInt8(version, 0);
 	buffer.copy(payload, 1);
 

--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -66,12 +66,11 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 			var keysgroupBuffer = Buffer.from(transaction.asset.multisignature.keysgroup.join(""), "utf8");
 			var bb = new ByteBuffer(1 + 1 + keysgroupBuffer.length, true);
 
-			bb.writeByte(transaction.asset.multisignature.min);
-			bb.writeByte(transaction.asset.multisignature.lifetime);
+			bb.writeInt8(transaction.asset.multisignature.min)
+			bb.writeInt8(transaction.asset.multisignature.lifetime)
 
-			for (var i = 0; i < keysgroupBuffer.length; i++) {
-				bb.writeByte(keysgroupBuffer[i]);
-			}
+			console.assert(keysgroupBuffer.length % 66 === 0)
+			bb.append(keysgroupBuffer)
 
 			bb.flip();
 
@@ -81,10 +80,11 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 	}
 
 	var assetLength = assetBytes !== null ? assetBytes.length : 0
-	var bb = new ByteBuffer(1 + 4 + 32 + 8 + 8 + 21 + 64 + 64 + 64 + assetLength, true);
+	var bb = new ByteBuffer(1 + 4 + 32 + 21 + 64 + 8 + 8 + assetLength + 64 + 64, true);
 	bb.writeByte(transaction.type);
-	bb.writeInt(transaction.timestamp);
+	bb.writeUint32(transaction.timestamp);
 
+	// FIXME: transaction.senderPublicKey can be 32 or 33 bytes
 	bb.append(transaction.senderPublicKey, "hex")
 
 	if (transaction.recipientId) {
@@ -92,7 +92,8 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 		console.assert(recipient.length === 21)
 		bb.append(recipient)
 	} else {
-		bb.append(Buffer.alloc(21, 0))
+		bb.fill(0, bb.offset, bb.offset + 21)
+		bb.skip(21)
 	}
 
 	if(transaction.vendorFieldHex){
@@ -103,12 +104,13 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 		var vf = Buffer.alloc(64, transaction.vendorField, "utf8")
 		bb.append(vf)
 	} else {
-		bb.append(Buffer.alloc(64, 0))
+		bb.fill(0, bb.offset, bb.offset + 64)
+		bb.skip(64)
 	}
 
-	bb.writeLong(transaction.amount);
+	bb.writeUint64(transaction.amount)
 
-	bb.writeLong(transaction.fee);
+	bb.writeUint64(transaction.fee)
 
 	if (assetLength > 0) {
 		bb.append(assetBytes)
@@ -136,11 +138,11 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 function fromBytes(hexString){
 	var tx={};
 	var buf = Buffer.from(hexString, "hex");
-	tx.type = buf.readInt8(0) & 0xff;
+	tx.type = buf.readInt8(0)
 	tx.timestamp = buf.readUInt32LE(1);
 	tx.senderPublicKey = hexString.substring(10,10+33*2);
-	tx.amount = buf.readUInt32LE(38+21+64);
-	tx.fee = buf.readUInt32LE(38+21+64+8);
+	tx.amount = buf.readUIntLE(38+21+64, 6) // TODO: read last 2 bytes, add tests
+	tx.fee = buf.readUIntLE(38+21+64+8, 6) // TODO: read last 2 bytes, add tests
 	tx.vendorFieldHex = hexString.substring(76+42,76+42+128);
   tx.recipientId = bs58check.encode(buf.slice(38,38+21));
 	if(tx.type == 0){ // transfer
@@ -183,11 +185,11 @@ function fromBytes(hexString){
 		tx.asset.multisignature.min = buffer.readInt8(0) & 0xff;
 		tx.asset.multisignature.lifetime = buffer.readInt8(1) & 0xff;
 		tx.asset.multisignature.keysgroup = [];
-		var index = 0;
-		while(index + 2 < buffer.length){
-			var key = buffer.slice(index+2,index+66+2).toString("utf8");
+		var index = 2;
+		while(index < buffer.length){
+			var key = buffer.slice(index, index + 66).toString("utf8");
 			tx.asset.multisignature.keysgroup.push(key);
-			index = index + 66;
+			index += 66;
 		}
 	}
 	else if(tx.type == 5){ // ipfs

--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -66,8 +66,8 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 			var keysgroupBuffer = Buffer.from(transaction.asset.multisignature.keysgroup.join(""), "utf8");
 			var bb = new ByteBuffer(1 + 1 + keysgroupBuffer.length, true);
 
-			bb.writeInt8(transaction.asset.multisignature.min)
-			bb.writeInt8(transaction.asset.multisignature.lifetime)
+			bb.writeUint8(transaction.asset.multisignature.min)
+			bb.writeUint8(transaction.asset.multisignature.lifetime)
 
 			console.assert(keysgroupBuffer.length % 66 === 0)
 			bb.append(keysgroupBuffer)
@@ -96,12 +96,15 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
 		bb.skip(21)
 	}
 
-	if(transaction.vendorFieldHex){
-		var vf = Buffer.alloc(64, transaction.vendorFieldHex, "hex")
+	if (transaction.vendorFieldHex) {
+		var vf = Buffer.allocUnsafe(64)
+		var written = vf.write(transaction.vendorFieldHex, 0, 64, 'hex')
+		vf.fill(0, written)
 		bb.append(vf)
-	}
-	else if (transaction.vendorField) {
-		var vf = Buffer.alloc(64, transaction.vendorField, "utf8")
+	} else if (transaction.vendorField) {
+		var vf = Buffer.allocUnsafe(64)
+		var written = vf.write(transaction.vendorField, 0, 64, 'utf8')
+		vf.fill(0, written)
 		bb.append(vf)
 	} else {
 		bb.fill(0, bb.offset, bb.offset + 64)
@@ -135,67 +138,77 @@ function getBytes(transaction, skipSignature, skipSecondSignature) {
  * @param {string} hexString
  * @returns {Transaction}
  */
-function fromBytes(hexString){
-	var tx={};
-	var buf = Buffer.from(hexString, "hex");
-	tx.type = buf.readInt8(0)
-	tx.timestamp = buf.readUInt32LE(1);
-	tx.senderPublicKey = hexString.substring(10,10+33*2);
-	tx.amount = buf.readUIntLE(38+21+64, 6) // TODO: read last 2 bytes, add tests
-	tx.fee = buf.readUIntLE(38+21+64+8, 6) // TODO: read last 2 bytes, add tests
-	tx.vendorFieldHex = hexString.substring(76+42,76+42+128);
-  tx.recipientId = bs58check.encode(buf.slice(38,38+21));
-	if(tx.type == 0){ // transfer
-		parseSignatures(hexString, tx, 76+42+128+32);
-	}
-	else if(tx.type == 1){ // second signature registration
-		delete tx.recipientId;
-		tx.asset = {
-			signature : {
-				publicKey : hexString.substring(76+42+128+32,76+42+128+32+66)
-			}
-		}
-		parseSignatures(hexString, tx, 76+42+128+32+66);
-	}
-	else if(tx.type == 2){ // delegate registration
-		delete tx.recipientId;
-		// Impossible to assess size of delegate asset, trying to grab signature and derive delegate asset
-		var offset = findAndParseSignatures(hexString, tx);
+function fromBytes (hexString) {
+	console.assert(typeof hexString === 'string' && hexString.length > 32)
 
+	var tx = {}
+	var buf = Buffer.from(hexString, "hex")
+	tx.type = buf.readInt8(0)
+	tx.timestamp = buf.readUInt32LE(1)
+	tx.senderPublicKey = hexString.substr(10, 33*2)
+	tx.vendorFieldHex = hexString.substr(10+33*2+42, 128)
+	var AMOUNT_OFFSET = 38 + 21 + 64
+	tx.amount = buf.readUIntLE(AMOUNT_OFFSET, 6) // TODO: read last 2 bytes, add tests
+	tx.fee = buf.readUIntLE(AMOUNT_OFFSET + 8, 6) // TODO: read last 2 bytes, add tests
+
+	var ASSET_OFFSET = 76 + 42 + 128 + 32
+	switch (tx.type) {
+	case 0: // transfer
+		tx.recipientId = bs58check.encode(buf.slice(38, 38 + 21))
+		parseSignatures(hexString, tx, ASSET_OFFSET)
+		break
+	case 1: // second signature registration
 		tx.asset = {
-			delegate: {
-				username: Buffer.from(hexString.substring(76+42+128+32,hexString.length-offset),"hex").toString("utf8")
+			signature: {
+				publicKey: hexString.substr(ASSET_OFFSET, 66)
 			}
-		};
-	}
-	else if(tx.type == 3){ // vote
-		// Impossible to assess size of vote asset, trying to grab signature and derive vote asset
-		var offset = findAndParseSignatures(hexString, tx);
-		tx.asset = {
-			votes: Buffer.from(hexString.substring(76+42+128+32,hexString.length-offset),"hex").toString("utf8").split(",")
-		};
-	}
-	else if(tx.type == 4){ // multisignature creation
-		delete tx.recipientId;
-		var offset = findAndParseSignatures(hexString, tx);
-		var buffer = Buffer.from(hexString.substring(76+42+128+32,hexString.length-offset),"hex")
-		tx.asset = {
-			multisignature: {}
 		}
-		tx.asset.multisignature.min = buffer.readInt8(0) & 0xff;
-		tx.asset.multisignature.lifetime = buffer.readInt8(1) & 0xff;
-		tx.asset.multisignature.keysgroup = [];
+		parseSignatures(hexString, tx, ASSET_OFFSET + 66)
+		break
+	case 2: // delegate registration
+		// Impossible to assess size of delegate asset, trying to grab signature and derive delegate asset
+		var offset = findAndParseSignatures(hexString, tx)
+		var username = Buffer
+			.from(hexString.substring(ASSET_OFFSET, hexString.length - offset), "hex")
+			.toString("utf8")
+		tx.asset = {
+			delegate: { username: username }
+		}
+		break
+	case 3: // vote
+		var offset = findAndParseSignatures(hexString, tx)
+		var votes = Buffer
+			.from(hexString.substring(ASSET_OFFSET, hexString.length - offset), "hex")
+			.toString("utf8")
+			.split(",")
+		tx.asset = { votes: votes }
+		break
+	case 4: // multisignature creation
+		var offset = findAndParseSignatures(hexString, tx)
+		var buffer = Buffer
+			.from(hexString.substring(ASSET_OFFSET, hexString.length - offset), "hex")
+		tx.asset = {
+			multisignature: {
+				min: buffer.readUInt8(0),
+				lifetime: buffer.readUInt8(1),
+				keysgroup: []
+			}
+		}
 		var index = 2;
-		while(index < buffer.length){
+		while (index < buffer.length) {
 			var key = buffer.slice(index, index + 66).toString("utf8");
 			tx.asset.multisignature.keysgroup.push(key);
 			index += 66;
 		}
+		break
+	case 5: // IPFS
+		parseSignatures(hexString, tx, ASSET_OFFSET)
+		break
+	default:
+		tx.recipientId = bs58check.encode(buf.slice(38, 38+21))
+		break
 	}
-	else if(tx.type == 5){ // ipfs
-		delete tx.recipientId;
-		parseSignatures(hexString, tx, 76+42+128+32);
-	}
+
 	return tx;
 }
 
@@ -206,7 +219,7 @@ function fromBytes(hexString){
  * @returns {number}
  */
 function findAndParseSignatures(hexString, tx){
-	var signature1 = Buffer.from(hexString.substring(hexString.length-146), "hex");
+	var signature1 = Buffer.from(hexString.substr(-146), "hex")
 	var signature2 = null;
 	var found      = false;
 	var offset     = 0;

--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -10,10 +10,6 @@ var networks = require("../networks.js")
 
 var bs58check = require('bs58check')
 
-if (typeof Buffer === "undefined") {
-	Buffer = require("buffer/").Buffer;
-}
-
 var ByteBuffer = require("bytebuffer");
 var bignum = require("browserify-bignum");
 

--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -33,7 +33,8 @@ function isECPair(obj) {
  * @returns {Uint8Array}
  */
 function getSignatureBytes(signature) {
-	var buffer = Buffer.alloc(33, signature.publicKey, "hex")
+	var buffer = Buffer.from(signature.publicKey, "hex")
+	console.assert(buffer.length === 33)
 	return new Uint8Array(buffer)
 }
 

--- a/lib/transactions/ipfs.js
+++ b/lib/transactions/ipfs.js
@@ -21,7 +21,7 @@ function createHashRegistration(ipfshash, secret, secondSecret) {
 		asset: {}
 	};
 
-  transaction.vendorFieldHex = new Buffer(ipfshash,"utf8").toString("hex");
+  transaction.vendorFieldHex = Buffer.from(ipfshash,"utf8").toString("hex");
   //filling with 0x00
   while(transaction.vendorFieldHex.length < 128){
     transaction.vendorFieldHex = "00"+transaction.vendorFieldHex;

--- a/lib/transactions/multisignature.js
+++ b/lib/transactions/multisignature.js
@@ -27,9 +27,9 @@ function signTransaction(trs, secret) {
  * @static
  * @param {ECPair|string} secret
  * @param {ECPair|string} secondSecret
- * @param {*} keysgroup
- * @param {*} lifetime
- * @param {*} min
+ * @param {string[]} keysgroup utf8 strings
+ * @param {number} lifetime Int8
+ * @param {number} min Int8
  */
 function createMultisignature(secret, secondSecret, keysgroup, lifetime, min) {
 	if (!secret || !keysgroup || !lifetime || !min) return false;

--- a/lib/v2/transactions/crypto.js
+++ b/lib/v2/transactions/crypto.js
@@ -7,10 +7,6 @@ var networks = require("../../networks.js")
 
 var bs58check = require('bs58check')
 
-if (typeof Buffer === "undefined") {
-	Buffer = require("buffer/").Buffer;
-}
-
 var ByteBuffer = require("bytebuffer");
 
 

--- a/lib/v2/transactions/crypto.js
+++ b/lib/v2/transactions/crypto.js
@@ -1,3 +1,4 @@
+var Buffer = require('safe-buffer').Buffer
 var crypto = require("crypto");
 var crypto_utils = require("../../crypto.js");
 var ECPair = require("../../ecpair.js");
@@ -47,7 +48,7 @@ function getBytes(transaction) {
 			break;
 
 		case 2: // Delegate
-			var delegateBytes = new Buffer(transaction.asset.delegate.username, "utf8");
+			var delegateBytes = Buffer.from(transaction.asset.delegate.username, "utf8");
 			bb.writeByte(delegateBytes.length/2);
 			bb.append(delegateBytes,"hex");
 			break;
@@ -61,7 +62,7 @@ function getBytes(transaction) {
 			break;
 
 		case 4: // Multi-Signature
-			var keysgroupBuffer = new Buffer(transaction.asset.multisignature.keysgroup.join(""), "hex");
+			var keysgroupBuffer = Buffer.from(transaction.asset.multisignature.keysgroup.join(""), "hex");
 			bb.writeByte(transaction.asset.multisignature.min);
 			bb.writeByte(transaction.asset.multisignature.keysgroup.length);
 			bb.writeByte(transaction.asset.multisignature.lifetime);
@@ -97,7 +98,7 @@ function getBytes(transaction) {
 
 function fromBytes(hexString){
 	var tx={};
-	var buf = new Buffer(hexString, "hex");
+	var buf = Buffer.from(hexString, "hex");
 	tx.version = buf.readInt8(1) & 0xff;
 	tx.network = buf.readInt8(2) & 0xff;
 	tx.type = buf.readInt8(3) & 0xff;
@@ -259,8 +260,8 @@ function verify(transaction, network) {
 
 	var hash = getHash(transaction);
 
-	var signatureBuffer = new Buffer(transaction.signature, "hex");
-	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
+	var signatureBuffer = Buffer.from(transaction.signature, "hex");
+	var senderPublicKeyBuffer = Buffer.from(transaction.senderPublicKey, "hex");
 	var ecpair = ECPair.fromPublicKeyBuffer(senderPublicKeyBuffer, network);
 	var ecsignature = ECSignature.fromDER(signatureBuffer);
 	var res = ecpair.verify(hash, ecsignature);
@@ -273,8 +274,8 @@ function verifySecondSignature(transaction, publicKey, network) {
 
 	var hash = getHash(transaction);
 
-	var secondSignatureBuffer = new Buffer(transaction.secondSignature, "hex");
-	var publicKeyBuffer = new Buffer(publicKey, "hex");
+	var secondSignatureBuffer = Buffer.from(transaction.secondSignature, "hex");
+	var publicKeyBuffer = Buffer.from(publicKey, "hex");
 	var ecpair = ECPair.fromPublicKeyBuffer(publicKeyBuffer, network);
 	var ecsignature = ECSignature.fromDER(secondSignatureBuffer);
 	var res = ecpair.verify(hash, ecsignature);
@@ -294,9 +295,9 @@ function getAddress(publicKey, version){
 	if(!version){
 		version = networkVersion;
 	}
-	var buffer = crypto_utils.ripemd160(new Buffer(publicKey,'hex'));
+	var buffer = crypto_utils.ripemd160(Buffer.from(publicKey,'hex'));
 
-	var payload = new Buffer(21);
+	var payload = Buffer.alloc(21);
 	payload.writeUInt8(version, 0);
 	buffer.copy(payload, 1);
 

--- a/lib/v2/transactions/transfer.js
+++ b/lib/v2/transactions/transfer.js
@@ -1,7 +1,8 @@
+var Buffer = require('safe-buffer').Buffer
 var crypto = require("./crypto.js"),
     constants = require("../../constants.js"),
 		slots = require("../../time/slots.js");
-		
+
 function Transfer(){
 	this.id = null;
 	this.amount = 0;
@@ -25,7 +26,7 @@ Transfer.prototype.create = function(recipientId, amount){
 }
 
 Transfer.prototype.setVendorField = function(data, type){
-	this.vendorFieldHex = new Buffer(data, type).toString("hex");
+	this.vendorFieldHex = Buffer.from(data, type).toString("hex");
 	return this;
 }
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "bip66": "^1.1.5",
     "browserify-bignum": "^1.3.0-2",
     "bs58check": "^2.0.2",
-    "buffer": "^5.0.8",
     "bytebuffer": "^5.0.1",
     "create-hash": "^1.1.3",
     "create-hmac": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -63,10 +63,11 @@
     "wif": "^2.0.6"
   },
   "devDependencies": {
-    "eslint": "^4.10.0",
     "browserify": "^14.4.0",
+    "eslint": "^4.10.0",
     "jsdoc": "^3.5.5",
     "mocha": "^4.0.1",
+    "npm-run-all": "^4.1.2",
     "proxyquire": "^1.8.0",
     "should": "^13.1.3",
     "shx": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "node": ">=4"
   },
   "scripts": {
+    "build": "npm-run-all build:*",
     "build:browserify": "browserify index.js -o app.js",
-    "clean:browserify": "shx rm app.js",
     "build:docs": "jsdoc -c jsdoc.json",
-    "clean:docs": "shx rm -r ./docs",
+    "clean": "npm-run-all clean:*",
+    "clean:browserify": "shx rm app.js",
+    "clean:docs": "shx rm -r ./doc",
     "lint": "eslint .",
     "test": "mocha test/ark.js test/*/*"
   },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "ecurve": "^1.0.5",
     "js-nacl": "^1.2.2",
     "randombytes": "^2.0.5",
+    "safe-buffer": "^5.1.1",
     "secp256k1": "^3.3.0",
     "typeforce": "^1.11.7",
     "wif": "^2.0.6"

--- a/test/ark.js
+++ b/test/ark.js
@@ -1,4 +1,3 @@
-var Buffer = require("buffer/").Buffer;
 var should = require("should");
 var ark = require("../index.js");
 

--- a/test/crypto/index.js
+++ b/test/crypto/index.js
@@ -234,7 +234,7 @@ describe("crypto.js", function () {
       (keys).should.have.property("privateKey");
       (keys.publicKey).should.be.type("string").and.match(function () {
         try {
-          new Buffer(keys.publicKey, "hex");
+          Buffer.from(keys.publicKey, "hex");
         } catch (e) {
           return false;
         }
@@ -243,7 +243,7 @@ describe("crypto.js", function () {
       });
       (keys.privateKey).should.be.type("string").and.match(function () {
         try {
-          new Buffer(keys.privateKey, "hex");
+          Buffer.from(keys.privateKey, "hex");
         } catch (e) {
           return false;
         }
@@ -286,7 +286,7 @@ describe("crypto.js", function () {
       var keys = crypto.getKeys("secret second test to be sure it works correctly");
       var address = getAddress(keys.publicKey);
 
-      var Q = ecurve.Point.decodeFrom(curve, new Buffer(keys.publicKey, 'hex'))
+      var Q = ecurve.Point.decodeFrom(curve, Buffer.from(keys.publicKey, 'hex'))
       var keyPair = new ECPair(null, Q);
 
       (address).should.be.equal(keyPair.getAddress());
@@ -410,7 +410,7 @@ describe("delegate.js", function () {
       it("should have senderPublicKey in hex", function () {
         (trs).should.have.property("senderPublicKey").and.type("string").and.match(function () {
           try {
-            new Buffer(trs.senderPublicKey, "hex");
+            Buffer.from(trs.senderPublicKey, "hex");
           } catch (e) {
             return false;
           }
@@ -422,7 +422,7 @@ describe("delegate.js", function () {
       it("should have signature in hex", function () {
         (trs).should.have.property("signature").and.type("string").and.match(function () {
           try {
-            new Buffer(trs.signature, "hex");
+            Buffer.from(trs.signature, "hex");
           } catch (e) {
             return false;
           }
@@ -434,7 +434,7 @@ describe("delegate.js", function () {
       it("should have second signature in hex", function () {
         (trs).should.have.property("signSignature").and.type("string").and.match(function () {
           try {
-            new Buffer(trs.signSignature, "hex");
+            Buffer.from(trs.signSignature, "hex");
           } catch (e) {
             return false;
           }

--- a/test/crypto/index.js
+++ b/test/crypto/index.js
@@ -1,4 +1,4 @@
-var Buffer = require("buffer/").Buffer;
+var Buffer = require('safe-buffer').Buffer
 var should = require("should");
 var ark = require("../../index.js");
 var ECPair = require('../../lib/ecpair');

--- a/test/ecdsa/index.js
+++ b/test/ecdsa/index.js
@@ -7,6 +7,7 @@ var sinon = require('sinon')
 var sinonTest = require('sinon-test')(sinon)
 
 var BigInteger = require('bigi')
+var Buffer = require('safe-buffer').Buffer
 var ECSignature = require('../../lib/ecsignature')
 
 var curve = ecdsa.__curve
@@ -37,7 +38,7 @@ describe('ecdsa', function () {
         .onCall(2).returns(new BigInteger('42')) // valid
 
       var x = new BigInteger('1').toBuffer(32)
-      var h1 = new Buffer(32)
+      var h1 = Buffer.alloc(32)
       var k = ecdsa.deterministicGenerateK(h1, x, checkSig)
 
       assert.strictEqual(k.toString(), '42')
@@ -57,7 +58,7 @@ describe('ecdsa', function () {
       checkSig.onCall(1).returns(true) // good signature
 
       var x = new BigInteger('1').toBuffer(32)
-      var h1 = new Buffer(32)
+      var h1 = Buffer.alloc(32)
       var k = ecdsa.deterministicGenerateK(h1, x, checkSig)
 
       assert.strictEqual(k.toString(), '53')
@@ -108,7 +109,7 @@ describe('ecdsa', function () {
       it('verifies a valid signature for "' + f.message + '"', function () {
         var d = BigInteger.fromHex(f.d)
         var H = bcrypto.sha256(f.message)
-        var signature = ECSignature.fromDER(new Buffer(f.signature, 'hex'))
+        var signature = ECSignature.fromDER(Buffer.from(f.signature, 'hex'))
         var Q = curve.G.multiply(d)
 
         assert(ecdsa.verify(H, signature, Q))
@@ -122,7 +123,7 @@ describe('ecdsa', function () {
 
         var signature
         if (f.signature) {
-          signature = ECSignature.fromDER(new Buffer(f.signature, 'hex'))
+          signature = ECSignature.fromDER(Buffer.from(f.signature, 'hex'))
         } else if (f.signatureRaw) {
           signature = new ECSignature(new BigInteger(f.signatureRaw.r, 16), new BigInteger(f.signatureRaw.s, 16))
         }

--- a/test/ecpair/index.js
+++ b/test/ecpair/index.js
@@ -9,6 +9,7 @@ var sinon = require('sinon')
 var sinonTest = require('sinon-test')(sinon)
 
 var BigInteger = require('bigi')
+var Buffer = require('safe-buffer').Buffer
 var ECPair = require('../../lib/ecpair')
 
 var fixtures = require('./fixtures.json')
@@ -59,7 +60,7 @@ describe('ECPair', function () {
     fixtures.invalid.constructor.forEach(function (f) {
       it('throws ' + f.exception, function () {
         var d = f.d && new BigInteger(f.d)
-        var Q = f.Q && ecurve.Point.decodeFrom(curve, new Buffer(f.Q, 'hex'))
+        var Q = f.Q && ecurve.Point.decodeFrom(curve, Buffer.from(f.Q, 'hex'))
 
         assert.throws(function () {
           new ECPair(d, Q, f.options)
@@ -130,7 +131,7 @@ describe('ECPair', function () {
   })
 
   describe('makeRandom', function () {
-    var d = new Buffer('0404040404040404040404040404040404040404040404040404040404040404', 'hex')
+    var d = Buffer.from('0404040404040404040404040404040404040404040404040404040404040404', 'hex')
     var exWIF = 'S9hzwiZ5ziKjUiFpuZX4Lri3rUocDxZSTy7YzKKHvx8TSjUrYQ27'
 
     describe('uses randombytes RNG', function () {
@@ -214,7 +215,7 @@ describe('ECPair', function () {
 
     beforeEach(function () {
       keyPair = ECPair.makeRandom()
-      hash = new Buffer(32)
+      hash = Buffer.alloc(32)
     })
 
     describe('signing', function () {

--- a/test/ecsignature/index.js
+++ b/test/ecsignature/index.js
@@ -3,6 +3,7 @@
 var assert = require('assert')
 
 var BigInteger = require('bigi')
+var Buffer = require('safe-buffer').Buffer
 var ECSignature = require('../../lib/ecsignature')
 
 var fixtures = require('./fixtures.json')
@@ -22,7 +23,7 @@ describe('ECSignature', function () {
   describe('parseCompact', function () {
     fixtures.valid.forEach(function (f) {
       it('imports ' + f.compact.hex + ' correctly', function () {
-        var buffer = new Buffer(f.compact.hex, 'hex')
+        var buffer = Buffer.from(f.compact.hex, 'hex')
         var parsed = ECSignature.parseCompact(buffer)
 
         assert.strictEqual(parsed.compressed, f.compact.compressed)
@@ -34,7 +35,7 @@ describe('ECSignature', function () {
 
     fixtures.invalid.compact.forEach(function (f) {
       it('throws on ' + f.hex, function () {
-        var buffer = new Buffer(f.hex, 'hex')
+        var buffer = Buffer.from(f.hex, 'hex')
 
         assert.throws(function () {
           ECSignature.parseCompact(buffer)
@@ -57,7 +58,7 @@ describe('ECSignature', function () {
   describe('fromDER', function () {
     fixtures.valid.forEach(function (f) {
       it('imports ' + f.DER + ' correctly', function () {
-        var buffer = new Buffer(f.DER, 'hex')
+        var buffer = Buffer.from(f.DER, 'hex')
         var signature = ECSignature.fromDER(buffer)
 
         assert.strictEqual(signature.r.toString(), f.signature.r)
@@ -67,7 +68,7 @@ describe('ECSignature', function () {
 
     fixtures.invalid.DER.forEach(function (f) {
       it('throws "' + f.exception + '" for ' + f.hex, function () {
-        var buffer = new Buffer(f.hex, 'hex')
+        var buffer = Buffer.from(f.hex, 'hex')
 
         assert.throws(function () {
           ECSignature.fromDER(buffer)
@@ -100,7 +101,7 @@ describe('ECSignature', function () {
   describe('parseScriptSignature', function () {
     fixtures.valid.forEach(function (f) {
       it('imports ' + f.scriptSignature.hex + ' correctly', function () {
-        var buffer = new Buffer(f.scriptSignature.hex, 'hex')
+        var buffer = Buffer.from(f.scriptSignature.hex, 'hex')
         var parsed = ECSignature.parseScriptSignature(buffer)
 
         assert.strictEqual(parsed.signature.r.toString(), f.signature.r)
@@ -111,7 +112,7 @@ describe('ECSignature', function () {
 
     fixtures.invalid.scriptSignature.forEach(function (f) {
       it('throws on ' + f.hex, function () {
-        var buffer = new Buffer(f.hex, 'hex')
+        var buffer = Buffer.from(f.hex, 'hex')
 
         assert.throws(function () {
           ECSignature.parseScriptSignature(buffer)

--- a/test/hdnode/index.js
+++ b/test/hdnode/index.js
@@ -7,6 +7,7 @@ var sinon = require('sinon')
 var sinonTest = require('sinon-test')(sinon)
 
 var BigInteger = require('bigi')
+var Buffer = require('safe-buffer').Buffer
 var ECPair = require('../../lib/ecpair')
 var HDNode = require('../../lib/hdnode')
 
@@ -37,8 +38,7 @@ describe('HDNode', function () {
       var d = BigInteger.ONE
 
       keyPair = new ECPair(d, null)
-      chainCode = new Buffer(32)
-      chainCode.fill(1)
+      chainCode = Buffer.alloc(32, 1)
     })
 
     it('stores the keyPair/chainCode directly', function () {
@@ -65,7 +65,7 @@ describe('HDNode', function () {
 
     it('throws when an invalid length chain code is given', function () {
       assert.throws(function () {
-        new HDNode(keyPair, new Buffer(20))
+        new HDNode(keyPair, Buffer.alloc(20))
       }, /Expected property "1" of type Buffer\(Length: 32\), got Buffer\(Length: 20\)/)
     })
   })
@@ -117,9 +117,9 @@ describe('HDNode', function () {
 
     beforeEach(function () {
       keyPair = ECPair.makeRandom()
-      hash = new Buffer(32)
+      hash = Buffer.alloc(32)
 
-      var chainCode = new Buffer(32)
+      var chainCode = Buffer.alloc(32)
       hd = new HDNode(keyPair, chainCode)
     })
 

--- a/test/integration/basic.js
+++ b/test/integration/basic.js
@@ -2,12 +2,13 @@
 
 var assert = require('assert')
 var bigi = require('bigi')
+var Buffer = require('safe-buffer').Buffer
 var ark = require('../../')
 
 describe('ark-js (basic)', function () {
   it('can generate a random ark address', function () {
     // for testing only
-    function rng () { return new Buffer('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz') }
+    function rng () { return Buffer.from('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz') }
 
     // generate random keyPair
     var keyPair = ark.ECPair.makeRandom({ rng: rng })
@@ -28,7 +29,7 @@ describe('ark-js (basic)', function () {
 
   it('can generate a random keypair for alternative networks', function () {
     // for testing only
-    function rng () { return new Buffer('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz') }
+    function rng () { return Buffer.from('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz') }
 
     var bitcoin = ark.networks.bitcoin
 

--- a/test/integration/bip32.js
+++ b/test/integration/bip32.js
@@ -2,6 +2,7 @@
 
 var assert = require('assert')
 var bigi = require('bigi')
+var Buffer = require('safe-buffer').Buffer
 var ark = require('../../')
 var crypto = require('crypto')
 
@@ -52,7 +53,7 @@ describe('ark-js (BIP32)', function () {
 
       var d1 = child.keyPair.d
       var d2
-      var data = new Buffer(37)
+      var data = Buffer.alloc(37)
       serQP.copy(data, 0)
 
       // search index space until we find it

--- a/test/ipfs/index.js
+++ b/test/ipfs/index.js
@@ -59,7 +59,7 @@ describe("ipfs.js", function () {
     it("should have senderPublicKey as hex string", function () {
       (trs.senderPublicKey).should.be.type("string").and.match(function () {
         try {
-          new Buffer(trs.senderPublicKey, "hex")
+          Buffer.from(trs.senderPublicKey, "hex")
         } catch (e) {
           return false;
         }
@@ -83,7 +83,7 @@ describe("ipfs.js", function () {
     it("should have signature as hex string", function () {
       (trs.signature).should.be.type("string").and.match(function () {
         try {
-          new Buffer(trs.signature, "hex")
+          Buffer.from(trs.signature, "hex")
         } catch (e) {
           return false;
         }

--- a/test/ipfs/index.js
+++ b/test/ipfs/index.js
@@ -1,4 +1,4 @@
-var Buffer = require("buffer/").Buffer;
+var Buffer = require("safe-buffer").Buffer
 var should = require("should");
 var ark = require("../../index.js");
 

--- a/test/multisignature/index.js
+++ b/test/multisignature/index.js
@@ -1,4 +1,4 @@
-var Buffer = require("buffer/").Buffer;
+var Buffer = require("safe-buffer").Buffer
 var should = require("should");
 var ark = require("../../index.js");
 

--- a/test/signature/index.js
+++ b/test/signature/index.js
@@ -1,4 +1,4 @@
-var Buffer = require("buffer/").Buffer;
+var Buffer = require("safe-buffer").Buffer
 var should = require("should");
 var ark = require("../../index.js");
 

--- a/test/signature/index.js
+++ b/test/signature/index.js
@@ -89,7 +89,7 @@ describe("signature.js", function () {
         it("should have publicKey in hex", function () {
           (sgn.asset.signature.publicKey).should.be.type("string").and.match(function () {
             try {
-              new Buffer(sgn.asset.signature.publicKey);
+              Buffer.from(sgn.asset.signature.publicKey);
             } catch (e) {
               return false;
             }
@@ -99,7 +99,7 @@ describe("signature.js", function () {
         });
 
         it("should have publicKey in 33 bytes", function () {
-          var publicKey = new Buffer(sgn.asset.signature.publicKey, "hex");
+          var publicKey = Buffer.from(sgn.asset.signature.publicKey, "hex");
           (publicKey.length).should.be.equal(33);
         });
       });

--- a/test/slot/index.js
+++ b/test/slot/index.js
@@ -1,4 +1,4 @@
-var Buffer = require("buffer/").Buffer;
+var Buffer = require("safe-buffer").Buffer
 var should = require("should");
 var ark = require("../../index.js");
 

--- a/test/transaction/index.js
+++ b/test/transaction/index.js
@@ -80,7 +80,7 @@ describe("transaction.js", function () {
       it("should have senderPublicKey as hex string", function () {
         (trs.senderPublicKey).should.be.type("string").and.match(function () {
           try {
-            new Buffer(trs.senderPublicKey, "hex")
+            Buffer.from(trs.senderPublicKey, "hex")
           } catch (e) {
             return false;
           }
@@ -108,7 +108,7 @@ describe("transaction.js", function () {
       it("should have signature as hex string", function () {
         (trs.signature).should.be.type("string").and.match(function () {
           try {
-            new Buffer(trs.signature, "hex")
+            Buffer.from(trs.signature, "hex")
           } catch (e) {
             return false;
           }
@@ -124,7 +124,7 @@ describe("transaction.js", function () {
 
       it("should be deserialised correctly", function () {
         var deserialisedTx = ark.crypto.fromBytes(ark.crypto.getBytes(trs).toString("hex"));
-        deserialisedTx.vendorField = new Buffer(deserialisedTx.vendorFieldHex, "hex").toString("utf8")
+        deserialisedTx.vendorField = Buffer.from(deserialisedTx.vendorFieldHex, "hex").toString("utf8")
         delete deserialisedTx.vendorFieldHex;
         var keys = Object.keys(deserialisedTx)
         for(key in keys){
@@ -153,7 +153,7 @@ describe("transaction.js", function () {
       function BIP66_encode (r, s) {
         var lenR = r.length;
         var lenS = s.length;
-        var signature = new Buffer(6 + lenR + lenS);
+        var signature = Buffer.alloc(6 + lenR + lenS);
 
         // 0x30 [total-length] 0x02 [R-length] [R] 0x02 [S-length] [S]
         signature[0] = 0x30;
@@ -254,7 +254,7 @@ describe("transaction.js", function () {
       it("should have senderPublicKey as hex string", function () {
         (trs.senderPublicKey).should.be.type("string").and.match(function () {
           try {
-            new Buffer(trs.senderPublicKey, "hex")
+            Buffer.from(trs.senderPublicKey, "hex")
           } catch (e) {
             return false;
           }
@@ -282,7 +282,7 @@ describe("transaction.js", function () {
       it("should have signature as hex string", function () {
         (trs.signature).should.be.type("string").and.match(function () {
           try {
-            new Buffer(trs.signature, "hex")
+            Buffer.from(trs.signature, "hex")
           } catch (e) {
             return false;
           }
@@ -294,7 +294,7 @@ describe("transaction.js", function () {
       it("should have signSignature as hex string", function () {
         (trs.signSignature).should.be.type("string").and.match(function () {
           try {
-            new Buffer(trs.signSignature, "hex");
+            Buffer.from(trs.signSignature, "hex");
           } catch (e) {
             return false;
           }

--- a/test/transaction/index.js
+++ b/test/transaction/index.js
@@ -1,4 +1,4 @@
-var Buffer = require("buffer/").Buffer;
+var Buffer = require("safe-buffer").Buffer
 var should = require("should");
 var ark = require("../../index.js");
 

--- a/test/vote/index.js
+++ b/test/vote/index.js
@@ -101,7 +101,7 @@ describe("vote.js", function () {
       it("should have senderPublicKey hex string equal to sender public key", function () {
         (vt).should.have.property("senderPublicKey").and.be.type("string").and.match(function () {
           try {
-            new Buffer(vt.senderPublicKey, "hex");
+            Buffer.from(vt.senderPublicKey, "hex");
           } catch (e) {
             return false;
           }
@@ -113,7 +113,7 @@ describe("vote.js", function () {
       it("should have signature hex string", function () {
         (vt).should.have.property("signature").and.be.type("string").and.match(function () {
           try {
-            new Buffer(vt.signature, "hex");
+            Buffer.from(vt.signature, "hex");
           } catch (e) {
             return false;
           }
@@ -125,7 +125,7 @@ describe("vote.js", function () {
       it("should have second signature hex string", function () {
         (vt).should.have.property("signSignature").and.be.type("string").and.match(function () {
           try {
-            new Buffer(vt.signSignature, "hex");
+            Buffer.from(vt.signSignature, "hex");
           } catch (e) {
             return false;
           }
@@ -181,7 +181,7 @@ describe("vote.js", function () {
           vt.asset.votes.forEach(function (v) {
             (v).should.be.type("string").startWith("+").and.match(function () {
               try {
-                new Buffer(v.substring(1, v.length), "hex");
+                Buffer.from(v.substring(1, v.length), "hex");
               } catch (e) {
                 return false;
               }

--- a/test/vote/index.js
+++ b/test/vote/index.js
@@ -1,4 +1,4 @@
-var Buffer = require("buffer/").Buffer;
+var Buffer = require("safe-buffer").Buffer
 var should = require("should");
 var ark = require("../../index.js");
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -335,7 +335,7 @@ buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
 
-buffer@^5.0.2, buffer@^5.0.8:
+buffer@^5.0.2:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.8.tgz#84daa52e7cf2fa8ce4195bc5cf0f7809e0930b24"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,7 +56,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0:
+ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -342,6 +342,10 @@ buffer@^5.0.2, buffer@^5.0.8:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
+builtin-modules@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -561,6 +565,13 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
+
 defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
@@ -644,6 +655,10 @@ duplexer2@^0.1.2, duplexer2@~0.1.0, duplexer2@~0.1.2:
   dependencies:
     readable-stream "^2.0.2"
 
+duplexer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+
 ecdsa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/ecdsa/-/ecdsa-0.7.0.tgz#f65ce2300227b1628102902b2b93607c806de1d9"
@@ -678,6 +693,30 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.0.tgz#7a90d833efda6cfa6eac0f4949dbb0fad3a63206"
   dependencies:
     once "^1.4.0"
+
+error-ex@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  dependencies:
+    is-arrayish "^0.2.1"
+
+es-abstract@^1.4.3:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
 
 es6-object-assign@^1.0.3:
   version "1.1.0"
@@ -768,6 +807,18 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+event-stream@~3.3.0:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.3"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
+
 events@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -832,17 +883,25 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+
 formatio@1.2.0, formatio@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
   dependencies:
     samsam "1.x"
 
+from@~0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-function-bind@^1.0.2:
+function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
@@ -915,7 +974,7 @@ has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
-has@^1.0.0:
+has@^1.0.0, has@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
   dependencies:
@@ -952,6 +1011,10 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
+
+hosted-git-info@^2.1.4:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
 htmlescape@^1.1.0:
   version "1.1.1"
@@ -1042,9 +1105,27 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
 is-buffer@^1.1.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
+is-builtin-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
+  dependencies:
+    builtin-modules "^1.0.0"
+
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -1080,11 +1161,21 @@ is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
 is-resolvable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
   dependencies:
     tryit "^1.0.1"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 isarray@0.0.1, isarray@~0.0.1:
   version "0.0.1"
@@ -1135,6 +1226,10 @@ jsdoc@^3.5.5:
     strip-json-comments "~2.0.1"
     taffydb "2.6.2"
     underscore "~1.8.3"
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz#50183cd1b2d25275de069e9e71b467ac9eab973a"
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
@@ -1189,6 +1284,15 @@ lexical-scope@^1.2.0:
   dependencies:
     astw "^2.0.0"
 
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -1220,6 +1324,10 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+
 marked@~0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
@@ -1230,6 +1338,10 @@ md5.js@^1.3.4:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
 
 merge-descriptors@~1.0.0:
   version "1.0.1"
@@ -1349,6 +1461,29 @@ noop-logger@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
 
+normalize-package-data@^2.3.2:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
+  dependencies:
+    hosted-git-info "^2.1.4"
+    is-builtin-module "^1.0.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
+npm-run-all@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.2.tgz#90d62d078792d20669139e718621186656cea056"
+  dependencies:
+    ansi-styles "^3.2.0"
+    chalk "^2.1.0"
+    cross-spawn "^5.1.0"
+    memorystream "^0.3.1"
+    minimatch "^3.0.4"
+    ps-tree "^1.1.0"
+    read-pkg "^3.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
+
 npmlog@^4.0.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
@@ -1365,6 +1500,10 @@ number-is-nan@^1.0.0:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -1421,6 +1560,13 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
 
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
 path-browserify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
@@ -1447,6 +1593,18 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  dependencies:
+    pify "^3.0.0"
+
+pause-stream@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  dependencies:
+    through "~2.3"
+
 pbkdf2@^3.0.3:
   version "3.0.14"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.14.tgz#a35e13c64799b06ce15320f459c230e68e73bade"
@@ -1460,6 +1618,10 @@ pbkdf2@^3.0.3:
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -1517,6 +1679,12 @@ proxyquire@^1.8.0:
     fill-keys "^1.0.2"
     module-not-found-error "^1.0.0"
     resolve "~1.1.7"
+
+ps-tree@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
+  dependencies:
+    event-stream "~3.3.0"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -1582,6 +1750,14 @@ read-only-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/read-only-stream/-/read-only-stream-2.0.0.tgz#2724fd6a8113d73764ac288d4386270c1dbf17f0"
   dependencies:
     readable-stream "^2.0.2"
+
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
 
 readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6:
   version "2.3.3"
@@ -1697,7 +1873,7 @@ secp256k1@^3.3.0:
     prebuild-install "^2.0.0"
     safe-buffer "^5.1.0"
 
-semver@^5.3.0, semver@^5.4.1:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
@@ -1830,6 +2006,26 @@ source-map@~0.5.3:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
+spdx-correct@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
+  dependencies:
+    spdx-license-ids "^1.0.2"
+
+spdx-expression-parse@~1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz#9bdf2f20e1f40ed447fbe273266191fced51626c"
+
+spdx-license-ids@^1.0.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
+
+split@0.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  dependencies:
+    through "2"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -1847,6 +2043,12 @@ stream-combiner2@^1.1.1:
   dependencies:
     duplexer2 "~0.1.0"
     readable-stream "^2.0.2"
+
+stream-combiner@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
+  dependencies:
+    duplexer "~0.1.1"
 
 stream-http@^2.0.0:
   version "2.7.2"
@@ -1880,6 +2082,14 @@ string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string.prototype.padend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz#f3aaef7c1719f170c5eab1c32bf780d96e21f2f0"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.4.3"
+    function-bind "^1.0.2"
+
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -1901,6 +2111,10 @@ strip-ansi@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -1982,7 +2196,7 @@ through2@^2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-"through@>=2.2.7 <3", through@^2.3.6:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -2072,6 +2286,13 @@ util@0.10.3, util@~0.10.1:
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   dependencies:
     inherits "2.0.1"
+
+validate-npm-package-license@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
+  dependencies:
+    spdx-correct "~1.0.0"
+    spdx-expression-parse "~1.0.0"
 
 vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
The `new Buffer` syntax was deprecated in Node 5 to force explicit use of `alloc`, `allocUnsafe`, and `from` to improve code safety. However, these new methods are not available on Node 4. I added the `safe-buffer` package (recommend by eslint) to use the appropriate APIs on each version and avoid deprecation warnings.

Byte for loops were also replaced with `fill` and `skip` calls which should theoretically improve performance.