### PR TITLE
Allow defining Network Version

### DIFF
--- a/lib/transactions/transaction.js
+++ b/lib/transactions/transaction.js
@@ -11,12 +11,13 @@ var crypto = require("./crypto.js"),
  * @param {string|null} vendorField
  * @param {ECPair|string} secret
  * @param {ECPair|string} [secondSecret]
+ * @param {number} [version]
  * @returns {Transaction}
  */
-function createTransaction(recipientId, amount, vendorField, secret, secondSecret) {
+function createTransaction(recipientId, amount, vendorField, secret, secondSecret, version) {
 	if (!recipientId || !amount || !secret) return false;
 
-  if(!crypto.validateAddress(recipientId)){
+  if(!crypto.validateAddress(recipientId, version)){
     throw new Error("Wrong recipientId");
 	}
 


### PR DESCRIPTION
During working on a project and testing it on my custom test network,
trying to create a transaction failed due to using a different network
version than the standard Ark network.

This change adds a new optional version argument to createTransaction
which can be used to specify the address version that is used to
validate the passed in address.
The change is fully backwards compatible with prior versions of the
library.