### PR TITLE
Add network manager and update library name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 indent_style = space
-indent_size = 4
+indent_size = 2
 trim_trailing_whitespace = true
 
 [*.md]

--- a/__tests__/managers/network.spec.js
+++ b/__tests__/managers/network.spec.js
@@ -1,0 +1,13 @@
+import NetworkManager from '@/managers/network'
+import networkMainnet from '@/networks/ark/mainnet'
+
+describe('Network Manager', () => {
+  it('should be instantiated', () => {
+    expect(NetworkManager).toBeDefined()
+  })
+
+  it('should find mainnet by name', () => {
+    const mainnet = NetworkManager.findByName('mainnet')
+    expect(mainnet).toMatchObject(networkMainnet)
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import ApiClient from '@/api'
+import NetworkManager from '@/managers/network'
 import transactionBuilder from '@/builder'
 import configManager from '@/managers/config'
 import feeManager from '@/managers/fee'
-import defaultConfig from '@/networks/ark/devnet'
 
 export default class Ark {
   /**
@@ -11,7 +11,7 @@ export default class Ark {
    * @return {[type]}        [description]
    */
   constructor (config) {
-    this.setConfig(config || defaultConfig)
+    this.setConfig(config || NetworkManager.findByName('devnet'))
   }
 
   /**
@@ -53,5 +53,9 @@ export default class Ark {
    */
   getClient (host) {
     return new ApiClient(host)
+  }
+
+  static getNetworkManager () {
+    return NetworkManager
   }
 }

--- a/src/managers/network.js
+++ b/src/managers/network.js
@@ -1,0 +1,22 @@
+import _ from 'lodash'
+import networks from '@/networks/ark'
+
+export default class NetworkManager {
+
+  /**
+   * [getAll description]
+   * @return {[type]} [description]
+   */
+  static getAll ()  {
+    return networks
+  }
+
+  /**
+   * [findByName description]
+   * @param {String} name [description]
+   */
+  static findByName (name) {
+    return _.find(networks, { name })
+  }
+
+}

--- a/src/networks/ark/index.js
+++ b/src/networks/ark/index.js
@@ -1,0 +1,11 @@
+import bitcoin from './bitcoin'
+import devnet from './devnet'
+import mainnet from './mainnet'
+import testnet from './testnet'
+
+export default {
+  bitcoin,
+  devnet,
+  mainnet,
+  testnet
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,12 @@ module.exports = merge(require('./webpack.base'), {
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: '[name].js',
-    library: 'ark-javascript-client',
+    library: {
+      root: 'ArkClient',
+      amd: 'ark-javascript-client',
+      commonjs: 'ark-javascript-client'
+    },
+    libraryExport: 'default',
     libraryTarget: 'umd'
   },
 


### PR DESCRIPTION
I'm trying to use it in the browser and I noticed some details.

Also to modularize this we could separate these networks to something like: `@arkecosystem/utils-common-networks`. What do you think @faustbrian ?