### PR TITLE
Fix bug that caused 337 ARK in losses so far.

### DIFF
--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -461,8 +461,8 @@ function getAddress(publicKey, version){
 	if(!version){
 		version = networkVersion;
 	}
-	if (!(pubKeyRegex.test(publicKey)))
-		throw "publicKey must be in hex";
+	if (!pubKeyRegex.test(publicKey))
+		throw "publicKey is invalid";
 	var buffer = crypto_utils.ripemd160(new Buffer(publicKey, "hex"));
 	var payload = new Buffer(21);
 	payload.writeUInt8(version, 0);

--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -457,11 +457,13 @@ function getKeys(secret, network) {
  * @returns {string}
  */
 function getAddress(publicKey, version){
+	const pubKeyRegex = /^[0-9A-Fa-f]{66}$/;
 	if(!version){
 		version = networkVersion;
 	}
-	var buffer = crypto_utils.ripemd160(new Buffer(publicKey,'hex'));
-
+	if (!(pubKeyRegex.test(publicKey)))
+		throw "publicKey must be in hex";
+	var buffer = crypto_utils.ripemd160(new Buffer(publicKey, "hex"));
 	var payload = new Buffer(21);
 	payload.writeUInt8(version, 0);
 	buffer.copy(payload, 1);

--- a/lib/v2/transactions/crypto.js
+++ b/lib/v2/transactions/crypto.js
@@ -295,8 +295,8 @@ function getAddress(publicKey, version){
 	if(!version){
 		version = networkVersion;
 	}
-	if (!(pubKeyRegex.test(publicKey)))
-		throw "publicKey must be in hex";
+	if (!pubKeyRegex.test(publicKey))
+		throw "publicKey is invalid";
 	var buffer = crypto_utils.ripemd160(new Buffer(publicKey, "hex"));
 	var payload = new Buffer(21);
 	payload.writeUInt8(version, 0);

--- a/lib/v2/transactions/crypto.js
+++ b/lib/v2/transactions/crypto.js
@@ -291,11 +291,13 @@ function getKeys(secret, network) {
 }
 
 function getAddress(publicKey, version){
+	const pubKeyRegex = /^[0-9A-Fa-f]{66}$/;
 	if(!version){
 		version = networkVersion;
 	}
-	var buffer = crypto_utils.ripemd160(new Buffer(publicKey,'hex'));
-
+	if (!(pubKeyRegex.test(publicKey)))
+		throw "publicKey must be in hex";
+	var buffer = crypto_utils.ripemd160(new Buffer(publicKey, "hex"));
 	var payload = new Buffer(21);
 	payload.writeUInt8(version, 0);
 	buffer.copy(payload, 1);


### PR DESCRIPTION
Attempting to create a buffer from an invalid hex string (ie: containing alphabetic characters after F) will cause an empty buffer to be created, leading to a potential loss of funds. There is a previous reddit report of this issue: https://www.reddit.com/r/ArkEcosystem/comments/7p0w6d/friend_lost_his_ark/.

This is the address derived from an empty buffer: AW163ssqR9RyEVdFee57GoobLfEBfWBPHp

This was discovered randomly during Blockhack DE.

The bug is technically within the Buffer module used by ark-js. This commit throws an error if an invalid public key is passed to prevent more users from losing money.